### PR TITLE
feat(ootmm): expand error types (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 name = "ootmm"
 version = "0.1.0"
 dependencies = [
+ "serde_yaml",
  "thiserror 2.0.17",
 ]
 
@@ -4347,6 +4348,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,6 +5296,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crate/ootmm/Cargo.toml
+++ b/crate/ootmm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde_yaml = "0.9"
 thiserror = "2"
 
 [dev-dependencies]

--- a/crate/ootmm/src/error.rs
+++ b/crate/ootmm/src/error.rs
@@ -1,17 +1,138 @@
 //! Unified error types for the ootmm crate.
-//! TODO: Implement (Issue #30)
 
 use thiserror::Error;
 
 /// Top-level error type for ootmm operations.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Error parsing an expression.
     #[error("parse error: {0}")]
     Parse(#[from] crate::expr::ParseError),
 
+    /// Error evaluating an expression.
     #[error("evaluation error: {0}")]
     Eval(#[from] crate::expr::EvalError),
 
+    /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Item not found in the item database.
+    #[error("item not found: {0}")]
+    ItemNotFound(String),
+
+    /// Region not found in the world graph.
+    #[error("region not found: {0}")]
+    RegionNotFound(String),
+
+    /// Invalid logic expression encountered.
+    #[error("invalid logic expression: {0}")]
+    InvalidLogicExpression(String),
+
+    /// YAML parsing error.
+    #[error("YAML parse error: {0}")]
+    YamlParse(#[from] serde_yaml::Error),
+
+    /// Error loading world data.
+    #[error("world load error: {message}")]
+    WorldLoad {
+        /// Description of the world loading failure.
+        message: String,
+        /// Optional underlying cause.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+}
+
+/// A specialized Result type for ootmm operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// Creates an `ItemNotFound` error.
+    pub fn item_not_found(item: impl Into<String>) -> Self {
+        Self::ItemNotFound(item.into())
+    }
+
+    /// Creates a `RegionNotFound` error.
+    pub fn region_not_found(region: impl Into<String>) -> Self {
+        Self::RegionNotFound(region.into())
+    }
+
+    /// Creates an `InvalidLogicExpression` error.
+    pub fn invalid_logic(expr: impl Into<String>) -> Self {
+        Self::InvalidLogicExpression(expr.into())
+    }
+
+    /// Creates a `WorldLoad` error with just a message.
+    pub fn world_load(message: impl Into<String>) -> Self {
+        Self::WorldLoad {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Creates a `WorldLoad` error with a message and source error.
+    pub fn world_load_with_source(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::WorldLoad {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as StdError;
+
+    #[test]
+    fn test_item_not_found_error() {
+        let err = Error::item_not_found("HOOKSHOT");
+        assert_eq!(err.to_string(), "item not found: HOOKSHOT");
+    }
+
+    #[test]
+    fn test_region_not_found_error() {
+        let err = Error::region_not_found("Kokiri Forest");
+        assert_eq!(err.to_string(), "region not found: Kokiri Forest");
+    }
+
+    #[test]
+    fn test_invalid_logic_error() {
+        let err = Error::invalid_logic("has(HOOKSHOT) &&");
+        assert_eq!(
+            err.to_string(),
+            "invalid logic expression: has(HOOKSHOT) &&"
+        );
+    }
+
+    #[test]
+    fn test_world_load_error() {
+        let err = Error::world_load("failed to load dungeon data");
+        assert_eq!(
+            err.to_string(),
+            "world load error: failed to load dungeon data"
+        );
+    }
+
+    #[test]
+    fn test_world_load_with_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = Error::world_load_with_source("failed to read world file", io_err);
+        assert_eq!(
+            err.to_string(),
+            "world load error: failed to read world file"
+        );
+        assert!(StdError::source(&err).is_some());
+    }
+
+    #[test]
+    fn test_io_error_conversion() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let err: Error = io_err.into();
+        assert!(matches!(err, Error::Io(_)));
+    }
 }


### PR DESCRIPTION
## Summary
- Expands error handling in crate/ootmm/src/error.rs
- Added new error variants:
  - ItemNotFound(String) - for missing items in the item database
  - RegionNotFound(String) - for missing regions in the world graph
  - InvalidLogicExpression(String) - for invalid logic expressions
  - YamlParse - wraps serde_yaml::Error with #[from] conversion
  - WorldLoad - struct variant with message and optional source for chained errors
- Added helper constructors for ergonomic error creation
- Added Result<T> type alias for the crate
- Added serde_yaml = "0.9" dependency

## Test plan
- [x] 6 unit tests for error types
- [x] cargo fmt passes
- [x] cargo clippy passes with 0 warnings
- [x] cargo test passes

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)