### PR TITLE
test: add test fixtures infrastructure (#34)

### DIFF
--- a/crate/oottracker/tests/common/mod.rs
+++ b/crate/oottracker/tests/common/mod.rs
@@ -1,0 +1,75 @@
+//! Common test utilities for oottracker integration tests.
+//!
+//! This module provides helper functions for loading and working with test fixtures.
+
+use std::path::PathBuf;
+
+/// Returns the path to a fixture file.
+///
+/// # Arguments
+///
+/// * `name` - The name of the fixture file (relative to the fixtures directory)
+///
+/// # Example
+///
+/// ```ignore
+/// let path = fixture_path("knowledge/default.json");
+/// ```
+pub fn fixture_path(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push(name);
+    path
+}
+
+/// Loads a fixture file and returns its contents as a String.
+///
+/// # Arguments
+///
+/// * `name` - The name of the fixture file (relative to the fixtures directory)
+///
+/// # Panics
+///
+/// Panics if the fixture file does not exist or cannot be read.
+///
+/// # Example
+///
+/// ```ignore
+/// let content = load_fixture("knowledge/default.json");
+/// let knowledge: Knowledge = serde_json::from_str(&content).unwrap();
+/// ```
+pub fn load_fixture(name: &str) -> String {
+    let path = fixture_path(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to load fixture '{}' at {:?}: {}", name, path, e))
+}
+
+/// Loads a fixture file and returns its contents as bytes.
+///
+/// Useful for binary fixtures like save data.
+///
+/// # Arguments
+///
+/// * `name` - The name of the fixture file (relative to the fixtures directory)
+///
+/// # Panics
+///
+/// Panics if the fixture file does not exist or cannot be read.
+pub fn load_fixture_bytes(name: &str) -> Vec<u8> {
+    let path = fixture_path(name);
+    std::fs::read(&path)
+        .unwrap_or_else(|e| panic!("Failed to load fixture '{}' at {:?}: {}", name, path, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fixture_path() {
+        let path = fixture_path("test.json");
+        assert!(path.ends_with("tests/fixtures/test.json"));
+        assert!(path.is_absolute() || path.starts_with(env!("CARGO_MANIFEST_DIR")));
+    }
+}

--- a/crate/oottracker/tests/fixtures/README.md
+++ b/crate/oottracker/tests/fixtures/README.md
@@ -1,0 +1,57 @@
+# Test Fixtures
+
+This directory contains test fixture files for the oottracker crate.
+
+## Directory Structure
+
+```
+fixtures/
+├── README.md           # This file
+└── knowledge/          # Knowledge-related fixtures
+    ├── default.json    # Default (empty) knowledge state
+    └── vanilla.json    # Vanilla game knowledge state
+```
+
+## Usage
+
+Use the helper functions from `tests/common/mod.rs` to load fixtures in your tests:
+
+```rust
+mod common;
+
+use common::{fixture_path, load_fixture, load_fixture_bytes};
+
+#[test]
+fn test_with_fixture() {
+    // Load fixture as string (for JSON, TOML, etc.)
+    let content = load_fixture("knowledge/default.json");
+    let knowledge: Knowledge = serde_json::from_str(&content).unwrap();
+
+    // Get fixture path for custom handling
+    let path = fixture_path("knowledge/vanilla.json");
+
+    // Load binary fixtures
+    let bytes = load_fixture_bytes("save/example.bin");
+}
+```
+
+## Adding New Fixtures
+
+1. Create an appropriate subdirectory if needed (e.g., `save/`, `config/`)
+2. Add your fixture file with a descriptive name
+3. Update this README if adding a new category of fixtures
+
+## Fixture Categories
+
+### knowledge/
+
+JSON files representing `Knowledge` states for testing knowledge serialization and game state tracking.
+
+- `default.json` - Empty/default knowledge state
+- `vanilla.json` - Knowledge state for vanilla (non-randomized) game
+
+## Notes
+
+- JSON fixtures should be valid according to the `KnowledgeJson` schema
+- Binary fixtures (e.g., save data) should be in the appropriate format for the data type
+- Keep fixture files small and focused on specific test scenarios

--- a/crate/oottracker/tests/fixtures/knowledge/default.json
+++ b/crate/oottracker/tests/fixtures/knowledge/default.json
@@ -1,0 +1,8 @@
+{
+  "settings": {},
+  "dungeons": {},
+  "trials": {},
+  "entrances": {},
+  "locations": {},
+  "progression_mode": "normal"
+}

--- a/crate/oottracker/tests/fixtures/knowledge/vanilla.json
+++ b/crate/oottracker/tests/fixtures/knowledge/vanilla.json
@@ -1,0 +1,52 @@
+{
+  "settings": {
+    "open_door_of_time": false,
+    "triforce_hunt": false,
+    "all_reachable": true,
+    "bombchus_in_logic": false,
+    "one_item_per_dungeon": false,
+    "trials_random": false,
+    "skip_child_zelda": false,
+    "open_forest": ["closed"],
+    "open_kakariko": ["closed"],
+    "zora_fountain": ["closed"],
+    "gerudo_fortress": ["normal"],
+    "bridge": ["vanilla"],
+    "logic_rules": ["glitchless"]
+  },
+  "dungeons": {
+    "Deku Tree": "vanilla",
+    "Dodongos Cavern": "vanilla",
+    "Jabu Jabus Belly": "vanilla",
+    "Forest Temple": "vanilla",
+    "Fire Temple": "vanilla",
+    "Water Temple": "vanilla",
+    "Shadow Temple": "vanilla",
+    "Spirit Temple": "vanilla",
+    "Ice Cavern": "vanilla",
+    "Bottom of the Well": "vanilla",
+    "Gerudo Training Ground": "vanilla",
+    "Ganons Castle": "vanilla"
+  },
+  "trials": {
+    "light": "active",
+    "forest": "active",
+    "fire": "active",
+    "water": "active",
+    "shadow": "active",
+    "spirit": "active"
+  },
+  "entrances": {},
+  "locations": {
+    "Queen Gohma": ["Kokiri Emerald"],
+    "King Dodongo": ["Goron Ruby"],
+    "Barinade": ["Zora Sapphire"],
+    "Phantom Ganon": ["Forest Medallion"],
+    "Volvagia": ["Fire Medallion"],
+    "Morpha": ["Water Medallion"],
+    "Bongo Bongo": ["Shadow Medallion"],
+    "Twinrova": ["Spirit Medallion"],
+    "Links Pocket": ["Light Medallion"]
+  },
+  "progression_mode": "go"
+}

--- a/crate/oottracker/tests/fixtures_test.rs
+++ b/crate/oottracker/tests/fixtures_test.rs
@@ -1,0 +1,39 @@
+//! Integration tests for test fixtures infrastructure.
+
+mod common;
+
+use common::{fixture_path, load_fixture, load_fixture_bytes};
+
+#[test]
+fn test_fixture_path_returns_valid_path() {
+    let path = fixture_path("knowledge/default.json");
+    assert!(path.ends_with("tests/fixtures/knowledge/default.json"));
+}
+
+#[test]
+fn test_load_fixture_reads_json() {
+    let content = load_fixture("knowledge/default.json");
+    assert!(content.contains("progression_mode"));
+}
+
+#[test]
+fn test_load_vanilla_fixture() {
+    let content = load_fixture("knowledge/vanilla.json");
+    // Verify it contains expected vanilla settings
+    assert!(content.contains("open_door_of_time"));
+    assert!(content.contains("Deku Tree"));
+}
+
+#[test]
+fn test_fixture_parses_as_json() {
+    let content = load_fixture("knowledge/default.json");
+    let _: serde_json::Value = serde_json::from_str(&content).expect("should be valid JSON");
+}
+
+#[test]
+fn test_load_fixture_bytes() {
+    let bytes = load_fixture_bytes("knowledge/default.json");
+    assert!(!bytes.is_empty());
+    // Verify it starts with a JSON object ('{')
+    assert_eq!(bytes[0], b'{');
+}


### PR DESCRIPTION
## Summary
- Creates test fixture infrastructure for the crate
- crate/oottracker/tests/common/mod.rs with helper functions:
  - fixture_path(name: &str) -> PathBuf
  - load_fixture(name: &str) -> String
  - load_fixture_bytes(name: &str) -> Vec<u8>
- crate/oottracker/tests/fixtures/ directory structure
- Sample fixture files (knowledge/default.json, knowledge/vanilla.json)
- README.md explaining fixture usage
- Integration tests validating the fixture infrastructure

## Test plan
- [x] 6 tests validating fixture loading
- [x] cargo fmt passes
- [x] cargo test passes

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)