### PR TITLE
ci: add code coverage reporting (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,26 @@ jobs:
       - name: Run tests
         run: cargo test -p ootr -p ootr-dynamic -p oottracker-derive
 
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin -p ootr -p ootr-dynamic -p oottracker-derive --out xml --output-dir coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: false
+          verbose: true
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![CI](https://github.com/spencerduncan/oottracker/actions/workflows/ci.yml/badge.svg)](https://github.com/spencerduncan/oottracker/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/spencerduncan/oottracker/branch/main/graph/badge.svg)](https://codecov.io/gh/spencerduncan/oottracker)
+
 **Warning:** As of 2021-11-15, [the racing rules](https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules) prohibit all usage of trackers capable of auto-tracking even in manual mode. How exactly this applies to my tracker is unclear pending a decision from the RaceMods.
 
 This is [Fenhl](https://github.com/fenhl)'s tracker for [the *Ocarina of Time* Item Randomizer](https://ootrandomizer.com/). Current features include:


### PR DESCRIPTION
## Summary
- Adds code coverage job to .github/workflows/ci.yml
- Uses cargo-tarpaulin to generate coverage for core crates (ootr, ootr-dynamic, oottracker-derive)
- Generates XML coverage report
- Uploads to Codecov using codecov/codecov-action@v4
- Added badges to README.md:
  - CI status badge
  - Codecov coverage badge
- Verified workflow YAML syntax is valid

## Test plan
- [x] Workflow YAML syntax validated
- [x] cargo fmt passes
- [x] No formatting changes needed

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)