### PR TITLE
fix(clippy): box large error types (#51)

### DIFF
--- a/crate/oottracker/src/lib.rs
+++ b/crate/oottracker/src/lib.rs
@@ -8,7 +8,6 @@
 )]
 #![allow(
     clippy::large_enum_variant,
-    clippy::result_large_err,
     clippy::result_unit_err,
     clippy::too_many_arguments,
     clippy::type_complexity,

--- a/crate/oottracker/src/proto.rs
+++ b/crate/oottracker/src/proto.rs
@@ -78,7 +78,9 @@ pub async fn write(
     Ok(())
 }
 
-pub fn handshake_sync(tcp_stream: &mut std::net::TcpStream) -> Result<(), async_proto::WriteError> {
-    VERSION.write_sync(tcp_stream)?;
+pub fn handshake_sync(
+    tcp_stream: &mut std::net::TcpStream,
+) -> Result<(), Box<async_proto::WriteError>> {
+    VERSION.write_sync(tcp_stream).map_err(Box::new)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Fixes Clippy result_large_err warning
- Removed clippy::result_large_err from the allow list in crate/oottracker/src/lib.rs
- Boxed the error type in handshake_sync functions in crate/oottracker/src/proto.rs
- Changed return type from Result<(), BoxAsync_proto::WriteError>> to Result<(), Box::new>
- Updated error handling with .map_err(Box::new)

## Test plan
- [x] cargo fmt passes
- [x] cargo clippy --all-targets -- -D warnings passes
- [x] cargo test passes

Closes #51

🤖 Generated with [Claude Code](https://claude.ai/code)