### PR TITLE
refactor: add type aliases for complex types (#53)

### DIFF
--- a/crate/oottracker/src/firebase.rs
+++ b/crate/oottracker/src/firebase.rs
@@ -158,17 +158,17 @@ pub trait App: fmt::Debug + Send + Sync + 'static {
             }
             FortressMq => {
                 if value.as_bool().ok_or_else(|| value.clone())? {
-                    state
-                        .knowledge
-                        .string_settings
-                        .insert(format!("gerudo_fortress"), collect![format!("normal")]);
+                    state.knowledge.string_settings.insert(
+                        "gerudo_fortress".to_string(),
+                        collect!["normal".to_string()],
+                    );
                 } else {
                     // don't override local state that's consistent with the value received
                     if state
                         .knowledge
                         .string_settings
                         .get("gerudo_fortress")
-                        .map_or(false, |fort| fort.iter().eq(iter::once("normal")))
+                        .is_some_and(|fort| fort.iter().eq(iter::once("normal")))
                     {
                         state.knowledge.string_settings.remove("gerudo_fortress");
                     }
@@ -235,7 +235,7 @@ pub trait App: fmt::Debug + Send + Sync + 'static {
                         .knowledge
                         .mq
                         .get(&dungeon)
-                        .map_or(false, |&mq| mq == Mq::Mq)
+                        .is_some_and(|&mq| mq == Mq::Mq)
                     {
                         state.knowledge.mq.remove(&dungeon);
                     }
@@ -950,7 +950,7 @@ fn render_cell(cell_kind: TrackerCellKind, state: &ModelState) -> Json {
             .knowledge
             .string_settings
             .get("gerudo_fortress")
-            .map_or(false, |values| values.iter().eq(iter::once("normal")))),
+            .is_some_and(|values| values.iter().eq(iter::once("normal")))),
         Medallion(med) => json!(state.ram.save.quest_items.has(med)),
         MedallionLocation(med) => json!(match state
             .knowledge

--- a/crate/oottracker/src/lib.rs
+++ b/crate/oottracker/src/lib.rs
@@ -11,7 +11,6 @@
     clippy::result_large_err,
     clippy::result_unit_err,
     clippy::too_many_arguments,
-    clippy::type_complexity,
     clippy::wrong_self_convention,
     clippy::modulo_one
 )]

--- a/crate/oottracker/src/region.rs
+++ b/crate/oottracker/src/region.rs
@@ -8,6 +8,9 @@ use {
     std::{fmt, io, sync::Arc},
 };
 
+/// Type alias for the result of looking up all regions
+pub type AllRegionsResult<R> = Result<Arc<Vec<Arc<Region<R>>>>, RegionLookupError<R>>;
+
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""), Clone(bound = ""))]
 pub enum RegionLookupError<R: Rando> {
@@ -109,7 +112,7 @@ pub trait RegionExt {
     where
         <Self::R as Rando>::RegionName: PartialEq<N>;
     /// A thin wrapper around [`Rando::regions`] with this module's error type.
-    fn all(rando: &Self::R) -> Result<Arc<Vec<Arc<Region<Self::R>>>>, RegionLookupError<Self::R>>;
+    fn all(rando: &Self::R) -> AllRegionsResult<Self::R>;
     fn root(rando: &Self::R) -> Result<Arc<Region<Self::R>>, RegionLookupError<Self::R>>; //TODO glitched param
 }
 
@@ -123,7 +126,7 @@ impl<R: Rando> RegionExt for Region<R> {
         RegionLookup::by_name(rando, name)
     }
 
-    fn all(rando: &R) -> Result<Arc<Vec<Arc<Region<R>>>>, RegionLookupError<R>> {
+    fn all(rando: &R) -> AllRegionsResult<R> {
         rando.regions().map_err(RegionLookupError::Rando)
     }
 

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -35,6 +35,18 @@ use {
     rocket_util::{html, ToHtml},
 };
 
+/// Type alias for functions that check two boolean states from ModelState
+type StatePairChecker = Box<dyn Fn(&ModelState) -> (bool, bool)>;
+
+/// Type alias for functions that set a u8 value on ModelState
+type StateU8Setter = Box<dyn Fn(&mut ModelState, u8)>;
+
+/// Type alias for functions that return an image with active state from ModelState
+type StateImageGetter = Box<dyn Fn(&ModelState) -> (bool, ImageInfo)>;
+
+/// Type alias for functions that set small keys count
+type SmallKeysSetter = Box<dyn Fn(&mut crate::save::SmallKeys, u8)>;
+
 const VERSION: u8 = 0;
 
 #[derive(Debug, FromArc, Clone)]
@@ -239,7 +251,7 @@ pub enum TrackerCellKind {
         left_img: ImageInfo,
         right_img: ImageInfo,
         both_img: ImageInfo,
-        active: Box<dyn Fn(&ModelState) -> (bool, bool)>,
+        active: StatePairChecker,
         toggle_left: Box<dyn Fn(&mut ModelState)>,
         toggle_right: Box<dyn Fn(&mut ModelState)>,
     },
@@ -251,7 +263,7 @@ pub enum TrackerCellKind {
         dimmed_img: ImageInfo,
         img: ImageInfo,
         get: Box<dyn Fn(&ModelState) -> u8>,
-        set: Box<dyn Fn(&mut ModelState, u8)>,
+        set: StateU8Setter,
         max: u8,
         step: u8,
     },
@@ -266,20 +278,20 @@ pub enum TrackerCellKind {
     OptionalOverlay {
         main_img: ImageInfo,
         overlay_img: ImageInfo,
-        active: Box<dyn Fn(&ModelState) -> (bool, bool)>,
+        active: StatePairChecker,
         toggle_main: Box<dyn Fn(&mut ModelState)>,
         toggle_overlay: Box<dyn Fn(&mut ModelState)>,
     },
     Overlay {
         main_img: ImageInfo,
         overlay_img: ImageInfo,
-        active: Box<dyn Fn(&ModelState) -> (bool, bool)>,
+        active: StatePairChecker,
         toggle_main: Box<dyn Fn(&mut ModelState)>,
         toggle_overlay: Box<dyn Fn(&mut ModelState)>,
     },
     Sequence {
         idx: Box<dyn Fn(&ModelState) -> u8>,
-        img: Box<dyn Fn(&ModelState) -> (bool, ImageInfo)>,
+        img: StateImageGetter,
         increment: Box<dyn Fn(&mut ModelState)>,
         decrement: Box<dyn Fn(&mut ModelState)>,
     },
@@ -290,7 +302,7 @@ pub enum TrackerCellKind {
     },
     SmallKeys {
         get: Box<dyn Fn(&crate::save::SmallKeys) -> u8>,
-        set: Box<dyn Fn(&mut crate::save::SmallKeys, u8)>,
+        set: SmallKeysSetter,
         max_vanilla: u8,
         max_mq: u8,
     },


### PR DESCRIPTION
## Summary
- Fixes Clippy type_complexity warnings
- Added 4 type aliases in crate/oottracker/src/ui.rs for complex function pointer types:
  - StatePairChecker - Box<dyn Fn(&ModelState) -> (bool, bool)>
  - StateObjSetter - Box<dyn Fn(&mut ModelState, u8)>
  - StateImageSetter - Box<dyn Fn(&ModelState) -> (bool, ImageInfo)>
  - SmallKeysSetter - Box<dyn Fn(&mut crate::save::SmallKeys, u8)>
- Added type alias in crate/oottracker/src/region.rs:
  - AllRegionsResult<R> - Result<Arc<Vec<Arc<Region<R>>>>, RegionLookupError<R>>
- Removed clippy::type_complexity from the allow list in crate/oottracker/src/lib.rs
- Fixed additional clippy warnings in crate/oottracker/src/firebase.rs:
  - Replaced format!() with to_string() for simple strings
  - Replaced map_or(false, ...) with is_some_and(...)

## Test plan
- [x] cargo fmt passes
- [x] cargo clippy -p oottracker --all-targets -- -D warnings passes
- [x] cargo test -p oottracker passes

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/code)