### PR TITLE
feat(ootmm): add shared Item enum and lookups (#21)

### DIFF
--- a/crate/ootmm/src/item.rs
+++ b/crate/ootmm/src/item.rs
@@ -9,6 +9,104 @@ pub use oot::OotItem;
 /// Combined item enum for both games.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Item {
+    /// An item from Ocarina of Time.
     Oot(OotItem),
+    /// An item from Majora's Mask.
     Mm(MmItem),
+}
+
+impl Item {
+    /// Look up an Item by its string name.
+    ///
+    /// Tries OoT items first, then MM items. Supports both PascalCase
+    /// variant names (e.g., "MasterSword") and snake_case names (e.g., "master_sword").
+    ///
+    /// Note: Items with identical names in both games (e.g., "Hookshot") will
+    /// return the OoT variant. Use `OotItem::by_name` or `MmItem::by_name`
+    /// directly if you need a specific game's item.
+    #[must_use]
+    pub fn by_name(name: &str) -> Option<Item> {
+        OotItem::by_name(name)
+            .map(Item::Oot)
+            .or_else(|| MmItem::by_name(name).map(Item::Mm))
+    }
+}
+
+impl From<OotItem> for Item {
+    fn from(item: OotItem) -> Self {
+        Item::Oot(item)
+    }
+}
+
+impl From<MmItem> for Item {
+    fn from(item: MmItem) -> Self {
+        Item::Mm(item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Item, MmItem, OotItem};
+
+    #[test]
+    fn test_from_oot_item() {
+        let item: Item = OotItem::MasterSword.into();
+        assert_eq!(item, Item::Oot(OotItem::MasterSword));
+    }
+
+    #[test]
+    fn test_from_mm_item() {
+        let item: Item = MmItem::DekuMask.into();
+        assert_eq!(item, Item::Mm(MmItem::DekuMask));
+    }
+
+    #[test]
+    fn test_by_name_oot_specific() {
+        // Items unique to OoT
+        assert_eq!(
+            Item::by_name("MasterSword"),
+            Some(Item::Oot(OotItem::MasterSword))
+        );
+        assert_eq!(
+            Item::by_name("master_sword"),
+            Some(Item::Oot(OotItem::MasterSword))
+        );
+        assert_eq!(
+            Item::by_name("Boomerang"),
+            Some(Item::Oot(OotItem::Boomerang))
+        );
+    }
+
+    #[test]
+    fn test_by_name_mm_specific() {
+        // Items unique to MM
+        assert_eq!(
+            Item::by_name("DekuMask"),
+            Some(Item::Mm(MmItem::DekuMask))
+        );
+        assert_eq!(
+            Item::by_name("deku_mask"),
+            Some(Item::Mm(MmItem::DekuMask))
+        );
+        assert_eq!(
+            Item::by_name("OdolwaRemains"),
+            Some(Item::Mm(MmItem::OdolwaRemains))
+        );
+    }
+
+    #[test]
+    fn test_by_name_shared_returns_oot() {
+        // Items that exist in both games should return OoT variant first
+        assert_eq!(
+            Item::by_name("Hookshot"),
+            Some(Item::Oot(OotItem::Hookshot))
+        );
+        assert_eq!(Item::by_name("Bomb"), Some(Item::Oot(OotItem::Bomb)));
+    }
+
+    #[test]
+    fn test_by_name_not_found() {
+        assert_eq!(Item::by_name("NotAnItem"), None);
+        assert_eq!(Item::by_name(""), None);
+    }
 }

--- a/crate/ootmm/src/item/mm.rs
+++ b/crate/ootmm/src/item/mm.rs
@@ -164,6 +164,164 @@ pub enum MmItem {
 }
 
 impl MmItem {
+    /// Look up an MmItem by its string name.
+    ///
+    /// Supports both PascalCase variant names (e.g., "DekuMask") and
+    /// snake_case names (e.g., "deku_mask").
+    #[must_use]
+    pub fn by_name(name: &str) -> Option<Self> {
+        let item = match name {
+            // Masks - Transformation
+            "DekuMask" | "deku_mask" => Self::DekuMask,
+            "GoronMask" | "goron_mask" => Self::GoronMask,
+            "ZoraMask" | "zora_mask" => Self::ZoraMask,
+            "FierceDeityMask" | "fierce_deity_mask" => Self::FierceDeityMask,
+            // Masks - Regular
+            "PostmanHat" | "postman_hat" => Self::PostmanHat,
+            "AllNightMask" | "all_night_mask" => Self::AllNightMask,
+            "BlastMask" | "blast_mask" => Self::BlastMask,
+            "StoneMask" | "stone_mask" => Self::StoneMask,
+            "GreatFairyMask" | "great_fairy_mask" => Self::GreatFairyMask,
+            "KeatonMask" | "keaton_mask" => Self::KeatonMask,
+            "BremenMask" | "bremen_mask" => Self::BremenMask,
+            "BunnyHood" | "bunny_hood" => Self::BunnyHood,
+            "DonGeroMask" | "don_gero_mask" => Self::DonGeroMask,
+            "MaskOfScents" | "mask_of_scents" => Self::MaskOfScents,
+            "RomaniMask" | "romani_mask" => Self::RomaniMask,
+            "CircusLeaderMask" | "circus_leader_mask" => Self::CircusLeaderMask,
+            "KafeiMask" | "kafei_mask" => Self::KafeiMask,
+            "CouplesMask" | "couples_mask" => Self::CouplesMask,
+            "MaskOfTruth" | "mask_of_truth" => Self::MaskOfTruth,
+            "KamaroMask" | "kamaro_mask" => Self::KamaroMask,
+            "GibdoMask" | "gibdo_mask" => Self::GibdoMask,
+            "GaroMask" | "garo_mask" => Self::GaroMask,
+            "CaptainHat" | "captain_hat" => Self::CaptainHat,
+            "GiantMask" | "giant_mask" => Self::GiantMask,
+            // Swords
+            "KokiriSword" | "kokiri_sword" => Self::KokiriSword,
+            "RazorSword" | "razor_sword" => Self::RazorSword,
+            "GildedSword" | "gilded_sword" => Self::GildedSword,
+            "GreatFairySword" | "great_fairy_sword" => Self::GreatFairySword,
+            // Shields
+            "HeroShield" | "hero_shield" => Self::HeroShield,
+            "MirrorShield" | "mirror_shield" => Self::MirrorShield,
+            // Equipment Items
+            "HerosBow" | "heros_bow" => Self::HerosBow,
+            "FireArrow" | "fire_arrow" => Self::FireArrow,
+            "IceArrow" | "ice_arrow" => Self::IceArrow,
+            "LightArrow" | "light_arrow" => Self::LightArrow,
+            "Bomb" | "bomb" => Self::Bomb,
+            "Bombchu" | "bombchu" => Self::Bombchu,
+            "DekuStick" | "deku_stick" => Self::DekuStick,
+            "DekuNut" | "deku_nut" => Self::DekuNut,
+            "MagicBean" | "magic_bean" => Self::MagicBean,
+            "PowderKeg" | "powder_keg" => Self::PowderKeg,
+            "Hookshot" | "hookshot" => Self::Hookshot,
+            "LensOfTruth" | "lens_of_truth" => Self::LensOfTruth,
+            "PictographBox" | "pictograph_box" => Self::PictographBox,
+            "OcarinaOfTime" | "ocarina_of_time" => Self::OcarinaOfTime,
+            // Bottles
+            "Bottle" | "bottle" => Self::Bottle,
+            "BottleRedPotion" | "bottle_red_potion" => Self::BottleRedPotion,
+            "BottleGreenPotion" | "bottle_green_potion" => Self::BottleGreenPotion,
+            "BottleBluePotion" | "bottle_blue_potion" => Self::BottleBluePotion,
+            "BottleFairy" | "bottle_fairy" => Self::BottleFairy,
+            "BottleDekuPrincess" | "bottle_deku_princess" => Self::BottleDekuPrincess,
+            "BottleFish" | "bottle_fish" => Self::BottleFish,
+            "BottleBugs" | "bottle_bugs" => Self::BottleBugs,
+            "BottlePoe" | "bottle_poe" => Self::BottlePoe,
+            "BottleBigPoe" | "bottle_big_poe" => Self::BottleBigPoe,
+            "BottleHotSpringWater" | "bottle_hot_spring_water" => Self::BottleHotSpringWater,
+            "BottleZoraEgg" | "bottle_zora_egg" => Self::BottleZoraEgg,
+            "BottleMushroom" | "bottle_mushroom" => Self::BottleMushroom,
+            "BottleGoldDust" | "bottle_gold_dust" => Self::BottleGoldDust,
+            "BottleMilk" | "bottle_milk" => Self::BottleMilk,
+            "BottleHalfMilk" | "bottle_half_milk" => Self::BottleHalfMilk,
+            "BottleChateau" | "bottle_chateau" => Self::BottleChateau,
+            "BottleSeaHorse" | "bottle_sea_horse" => Self::BottleSeaHorse,
+            // Songs
+            "SongOfTime" | "song_of_time" => Self::SongOfTime,
+            "SongOfHealing" | "song_of_healing" => Self::SongOfHealing,
+            "EponasSong" | "eponas_song" => Self::EponasSong,
+            "SongOfSoaring" | "song_of_soaring" => Self::SongOfSoaring,
+            "SongOfStorms" | "song_of_storms" => Self::SongOfStorms,
+            "SonataOfAwakening" | "sonata_of_awakening" => Self::SonataOfAwakening,
+            "GoronLullaby" | "goron_lullaby" => Self::GoronLullaby,
+            "NewWaveBossaNova" | "new_wave_bossa_nova" => Self::NewWaveBossaNova,
+            "ElegyOfEmptiness" | "elegy_of_emptiness" => Self::ElegyOfEmptiness,
+            "OathToOrder" | "oath_to_order" => Self::OathToOrder,
+            // Upgrades
+            "AdultWallet" | "adult_wallet" => Self::AdultWallet,
+            "GiantWallet" | "giant_wallet" => Self::GiantWallet,
+            "Quiver30" | "quiver_30" => Self::Quiver30,
+            "Quiver40" | "quiver_40" => Self::Quiver40,
+            "Quiver50" | "quiver_50" => Self::Quiver50,
+            "BombBag20" | "bomb_bag_20" => Self::BombBag20,
+            "BombBag30" | "bomb_bag_30" => Self::BombBag30,
+            "BombBag40" | "bomb_bag_40" => Self::BombBag40,
+            "MagicMeter" | "magic_meter" => Self::MagicMeter,
+            "DoubleMagic" | "double_magic" => Self::DoubleMagic,
+            "DoubleDefense" | "double_defense" => Self::DoubleDefense,
+            // Quest Items
+            "MoonsTear" | "moons_tear" => Self::MoonsTear,
+            "LandTitleDeed" | "land_title_deed" => Self::LandTitleDeed,
+            "SwampTitleDeed" | "swamp_title_deed" => Self::SwampTitleDeed,
+            "MountainTitleDeed" | "mountain_title_deed" => Self::MountainTitleDeed,
+            "OceanTitleDeed" | "ocean_title_deed" => Self::OceanTitleDeed,
+            "RoomKey" | "room_key" => Self::RoomKey,
+            "LetterToKafei" | "letter_to_kafei" => Self::LetterToKafei,
+            "PendantOfMemories" | "pendant_of_memories" => Self::PendantOfMemories,
+            "LetterToMama" | "letter_to_mama" => Self::LetterToMama,
+            "SpecialDeliveryToMama" | "special_delivery_to_mama" => Self::SpecialDeliveryToMama,
+            // Boss Remains
+            "OdolwaRemains" | "odolwa_remains" => Self::OdolwaRemains,
+            "GohtRemains" | "goht_remains" => Self::GohtRemains,
+            "GyorgRemains" | "gyorg_remains" => Self::GyorgRemains,
+            "TwinmoldRemains" | "twinmold_remains" => Self::TwinmoldRemains,
+            // Dungeon Items
+            "SmallKey" | "small_key" => Self::SmallKey,
+            "BossKey" | "boss_key" => Self::BossKey,
+            "Map" | "map" => Self::Map,
+            "Compass" | "compass" => Self::Compass,
+            "StrayFairy" | "stray_fairy" => Self::StrayFairy,
+            // Dungeon-Specific Keys
+            "SmallKeyWoodfallTemple" | "small_key_woodfall_temple" => Self::SmallKeyWoodfallTemple,
+            "SmallKeySnowheadTemple" | "small_key_snowhead_temple" => Self::SmallKeySnowheadTemple,
+            "SmallKeyGreatBayTemple" | "small_key_great_bay_temple" => Self::SmallKeyGreatBayTemple,
+            "SmallKeyStoneTowerTemple" | "small_key_stone_tower_temple" => {
+                Self::SmallKeyStoneTowerTemple
+            }
+            "BossKeyWoodfallTemple" | "boss_key_woodfall_temple" => Self::BossKeyWoodfallTemple,
+            "BossKeySnowheadTemple" | "boss_key_snowhead_temple" => Self::BossKeySnowheadTemple,
+            "BossKeyGreatBayTemple" | "boss_key_great_bay_temple" => Self::BossKeyGreatBayTemple,
+            "BossKeyStoneTowerTemple" | "boss_key_stone_tower_temple" => {
+                Self::BossKeyStoneTowerTemple
+            }
+            // Stray Fairies per dungeon
+            "StrayFairyWoodfall" | "stray_fairy_woodfall" => Self::StrayFairyWoodfall,
+            "StrayFairySnowhead" | "stray_fairy_snowhead" => Self::StrayFairySnowhead,
+            "StrayFairyGreatBay" | "stray_fairy_great_bay" => Self::StrayFairyGreatBay,
+            "StrayFairyStoneTower" | "stray_fairy_stone_tower" => Self::StrayFairyStoneTower,
+            "StrayFairyClockTown" | "stray_fairy_clock_town" => Self::StrayFairyClockTown,
+            // Collectibles
+            "HeartContainer" | "heart_container" => Self::HeartContainer,
+            "PieceOfHeart" | "piece_of_heart" => Self::PieceOfHeart,
+            "GreenRupee" | "green_rupee" => Self::GreenRupee,
+            "BlueRupee" | "blue_rupee" => Self::BlueRupee,
+            "RedRupee" | "red_rupee" => Self::RedRupee,
+            "PurpleRupee" | "purple_rupee" => Self::PurpleRupee,
+            "SilverRupee" | "silver_rupee" => Self::SilverRupee,
+            "GoldRupee" | "gold_rupee" => Self::GoldRupee,
+            // Notebook Events
+            "BomberNotebook" | "bomber_notebook" => Self::BomberNotebook,
+            // Special
+            "GiantsWallet" | "giants_wallet" => Self::GiantsWallet,
+            "OceanTitleDeedTraded" | "ocean_title_deed_traded" => Self::OceanTitleDeedTraded,
+            _ => return None,
+        };
+        Some(item)
+    }
+
     /// Returns true if this is a transformation mask.
     #[must_use]
     pub const fn is_transformation_mask(&self) -> bool {
@@ -310,5 +468,40 @@ mod tests {
         assert!(MmItem::Bomb.is_progressive());
         assert!(MmItem::StrayFairy.is_progressive());
         assert!(!MmItem::Hookshot.is_progressive());
+    }
+
+    #[test]
+    fn test_by_name_pascal_case() {
+        assert_eq!(MmItem::by_name("DekuMask"), Some(MmItem::DekuMask));
+        assert_eq!(MmItem::by_name("Hookshot"), Some(MmItem::Hookshot));
+        assert_eq!(
+            MmItem::by_name("OdolwaRemains"),
+            Some(MmItem::OdolwaRemains)
+        );
+        assert_eq!(
+            MmItem::by_name("SmallKeyWoodfallTemple"),
+            Some(MmItem::SmallKeyWoodfallTemple)
+        );
+    }
+
+    #[test]
+    fn test_by_name_snake_case() {
+        assert_eq!(MmItem::by_name("deku_mask"), Some(MmItem::DekuMask));
+        assert_eq!(MmItem::by_name("hookshot"), Some(MmItem::Hookshot));
+        assert_eq!(
+            MmItem::by_name("odolwa_remains"),
+            Some(MmItem::OdolwaRemains)
+        );
+        assert_eq!(
+            MmItem::by_name("small_key_woodfall_temple"),
+            Some(MmItem::SmallKeyWoodfallTemple)
+        );
+    }
+
+    #[test]
+    fn test_by_name_not_found() {
+        assert_eq!(MmItem::by_name("NotAnItem"), None);
+        assert_eq!(MmItem::by_name(""), None);
+        assert_eq!(MmItem::by_name("invalid_item"), None);
     }
 }

--- a/crate/ootmm/src/item/oot.rs
+++ b/crate/ootmm/src/item/oot.rs
@@ -182,6 +182,184 @@ pub enum OotItem {
 }
 
 impl OotItem {
+    /// Look up an OotItem by its string name.
+    ///
+    /// Supports both PascalCase variant names (e.g., "MasterSword") and
+    /// snake_case names (e.g., "master_sword").
+    #[must_use]
+    pub fn by_name(name: &str) -> Option<Self> {
+        // Try direct match first (PascalCase)
+        let item = match name {
+            // Swords
+            "KokiriSword" | "kokiri_sword" => Self::KokiriSword,
+            "MasterSword" | "master_sword" => Self::MasterSword,
+            "BiggoronSword" | "biggoron_sword" => Self::BiggoronSword,
+            "GiantKnife" | "giant_knife" => Self::GiantKnife,
+            // Shields
+            "DekuShield" | "deku_shield" => Self::DekuShield,
+            "HylianShield" | "hylian_shield" => Self::HylianShield,
+            "MirrorShield" | "mirror_shield" => Self::MirrorShield,
+            // Tunics
+            "KokiriTunic" | "kokiri_tunic" => Self::KokiriTunic,
+            "GoronTunic" | "goron_tunic" => Self::GoronTunic,
+            "ZoraTunic" | "zora_tunic" => Self::ZoraTunic,
+            // Boots
+            "KokiriBoots" | "kokiri_boots" => Self::KokiriBoots,
+            "IronBoots" | "iron_boots" => Self::IronBoots,
+            "HoverBoots" | "hover_boots" => Self::HoverBoots,
+            // Equipment Items
+            "DekuStick" | "deku_stick" => Self::DekuStick,
+            "DekuNut" | "deku_nut" => Self::DekuNut,
+            "Bomb" | "bomb" => Self::Bomb,
+            "Bow" | "bow" => Self::Bow,
+            "FireArrow" | "fire_arrow" => Self::FireArrow,
+            "IceArrow" | "ice_arrow" => Self::IceArrow,
+            "LightArrow" | "light_arrow" => Self::LightArrow,
+            "DinsFire" | "dins_fire" => Self::DinsFire,
+            "FaroresWind" | "farores_wind" => Self::FaroresWind,
+            "NayrusLove" | "nayrus_love" => Self::NayrusLove,
+            "Slingshot" | "slingshot" => Self::Slingshot,
+            "Boomerang" | "boomerang" => Self::Boomerang,
+            "Hookshot" | "hookshot" => Self::Hookshot,
+            "Longshot" | "longshot" => Self::Longshot,
+            "LensOfTruth" | "lens_of_truth" => Self::LensOfTruth,
+            "MegatonHammer" | "megaton_hammer" => Self::MegatonHammer,
+            "OcarinaOfTime" | "ocarina_of_time" => Self::OcarinaOfTime,
+            // C-Button Items
+            "Bottle" | "bottle" => Self::Bottle,
+            "BottleRedPotion" | "bottle_red_potion" => Self::BottleRedPotion,
+            "BottleGreenPotion" | "bottle_green_potion" => Self::BottleGreenPotion,
+            "BottleBluePotion" | "bottle_blue_potion" => Self::BottleBluePotion,
+            "BottleFairy" | "bottle_fairy" => Self::BottleFairy,
+            "BottleFish" | "bottle_fish" => Self::BottleFish,
+            "BottleBlueFire" | "bottle_blue_fire" => Self::BottleBlueFire,
+            "BottleBugs" | "bottle_bugs" => Self::BottleBugs,
+            "BottlePoe" | "bottle_poe" => Self::BottlePoe,
+            "BottleBigPoe" | "bottle_big_poe" => Self::BottleBigPoe,
+            "BottleMilk" | "bottle_milk" => Self::BottleMilk,
+            "BottleHalfMilk" | "bottle_half_milk" => Self::BottleHalfMilk,
+            "BottleRutosLetter" | "bottle_rutos_letter" => Self::BottleRutosLetter,
+            // Adult Trade Sequence
+            "PocketEgg" | "pocket_egg" => Self::PocketEgg,
+            "PocketCucco" | "pocket_cucco" => Self::PocketCucco,
+            "Cojiro" | "cojiro" => Self::Cojiro,
+            "OddMushroom" | "odd_mushroom" => Self::OddMushroom,
+            "OddPotion" | "odd_potion" => Self::OddPotion,
+            "PoachersSaw" | "poachers_saw" => Self::PoachersSaw,
+            "BrokenSword" | "broken_sword" => Self::BrokenSword,
+            "Prescription" | "prescription" => Self::Prescription,
+            "EyeballFrog" | "eyeball_frog" => Self::EyeballFrog,
+            "Eyedrops" | "eyedrops" => Self::Eyedrops,
+            "ClaimCheck" | "claim_check" => Self::ClaimCheck,
+            // Child Trade Sequence
+            "WeirdEgg" | "weird_egg" => Self::WeirdEgg,
+            "Chicken" | "chicken" => Self::Chicken,
+            "ZeldasLetter" | "zeldas_letter" => Self::ZeldasLetter,
+            "SkullMask" | "skull_mask" => Self::SkullMask,
+            "SpookyMask" | "spooky_mask" => Self::SpookyMask,
+            "KeatonMask" | "keaton_mask" => Self::KeatonMask,
+            "BunnyHood" | "bunny_hood" => Self::BunnyHood,
+            "GoronMask" | "goron_mask" => Self::GoronMask,
+            "ZoraMask" | "zora_mask" => Self::ZoraMask,
+            "GerudoMask" | "gerudo_mask" => Self::GerudoMask,
+            "MaskOfTruth" | "mask_of_truth" => Self::MaskOfTruth,
+            // Songs
+            "ZeldasLullaby" | "zeldas_lullaby" => Self::ZeldasLullaby,
+            "EponasSong" | "eponas_song" => Self::EponasSong,
+            "SariasSong" | "sarias_song" => Self::SariasSong,
+            "SunsSong" | "suns_song" => Self::SunsSong,
+            "SongOfTime" | "song_of_time" => Self::SongOfTime,
+            "SongOfStorms" | "song_of_storms" => Self::SongOfStorms,
+            "MinuetOfForest" | "minuet_of_forest" => Self::MinuetOfForest,
+            "BoleroOfFire" | "bolero_of_fire" => Self::BoleroOfFire,
+            "SerenadeOfWater" | "serenade_of_water" => Self::SerenadeOfWater,
+            "NocturneOfShadow" | "nocturne_of_shadow" => Self::NocturneOfShadow,
+            "RequiemOfSpirit" | "requiem_of_spirit" => Self::RequiemOfSpirit,
+            "PreludeOfLight" | "prelude_of_light" => Self::PreludeOfLight,
+            "ScarecrowSong" | "scarecrow_song" => Self::ScarecrowSong,
+            // Upgrades
+            "GoronBracelet" | "goron_bracelet" => Self::GoronBracelet,
+            "SilverGauntlets" | "silver_gauntlets" => Self::SilverGauntlets,
+            "GoldenGauntlets" | "golden_gauntlets" => Self::GoldenGauntlets,
+            "SilverScale" | "silver_scale" => Self::SilverScale,
+            "GoldenScale" | "golden_scale" => Self::GoldenScale,
+            "ChildWallet" | "child_wallet" => Self::ChildWallet,
+            "AdultWallet" | "adult_wallet" => Self::AdultWallet,
+            "GiantWallet" | "giant_wallet" => Self::GiantWallet,
+            "DekuStickCapacity20" | "deku_stick_capacity_20" => Self::DekuStickCapacity20,
+            "DekuStickCapacity30" | "deku_stick_capacity_30" => Self::DekuStickCapacity30,
+            "DekuNutCapacity30" | "deku_nut_capacity_30" => Self::DekuNutCapacity30,
+            "DekuNutCapacity40" | "deku_nut_capacity_40" => Self::DekuNutCapacity40,
+            "BulletBag30" | "bullet_bag_30" => Self::BulletBag30,
+            "BulletBag40" | "bullet_bag_40" => Self::BulletBag40,
+            "BulletBag50" | "bullet_bag_50" => Self::BulletBag50,
+            "Quiver30" | "quiver_30" => Self::Quiver30,
+            "Quiver40" | "quiver_40" => Self::Quiver40,
+            "Quiver50" | "quiver_50" => Self::Quiver50,
+            "BombBag20" | "bomb_bag_20" => Self::BombBag20,
+            "BombBag30" | "bomb_bag_30" => Self::BombBag30,
+            "BombBag40" | "bomb_bag_40" => Self::BombBag40,
+            "MagicMeter" | "magic_meter" => Self::MagicMeter,
+            "DoubleMagic" | "double_magic" => Self::DoubleMagic,
+            "DoubleDefense" | "double_defense" => Self::DoubleDefense,
+            // Quest Items
+            "KokiriEmerald" | "kokiri_emerald" => Self::KokiriEmerald,
+            "GoronRuby" | "goron_ruby" => Self::GoronRuby,
+            "ZoraSapphire" | "zora_sapphire" => Self::ZoraSapphire,
+            "ForestMedallion" | "forest_medallion" => Self::ForestMedallion,
+            "FireMedallion" | "fire_medallion" => Self::FireMedallion,
+            "WaterMedallion" | "water_medallion" => Self::WaterMedallion,
+            "ShadowMedallion" | "shadow_medallion" => Self::ShadowMedallion,
+            "SpiritMedallion" | "spirit_medallion" => Self::SpiritMedallion,
+            "LightMedallion" | "light_medallion" => Self::LightMedallion,
+            "StoneOfAgony" | "stone_of_agony" => Self::StoneOfAgony,
+            "GerudoCard" | "gerudo_card" => Self::GerudoCard,
+            // Dungeon Items
+            "SmallKey" | "small_key" => Self::SmallKey,
+            "BossKey" | "boss_key" => Self::BossKey,
+            "Map" | "map" => Self::Map,
+            "Compass" | "compass" => Self::Compass,
+            // Dungeon-Specific Keys
+            "SmallKeyForestTemple" | "small_key_forest_temple" => Self::SmallKeyForestTemple,
+            "SmallKeyFireTemple" | "small_key_fire_temple" => Self::SmallKeyFireTemple,
+            "SmallKeyWaterTemple" | "small_key_water_temple" => Self::SmallKeyWaterTemple,
+            "SmallKeyShadowTemple" | "small_key_shadow_temple" => Self::SmallKeyShadowTemple,
+            "SmallKeySpiritTemple" | "small_key_spirit_temple" => Self::SmallKeySpiritTemple,
+            "SmallKeyBottomOfTheWell" | "small_key_bottom_of_the_well" => {
+                Self::SmallKeyBottomOfTheWell
+            }
+            "SmallKeyGerudoFortress" | "small_key_gerudo_fortress" => Self::SmallKeyGerudoFortress,
+            "SmallKeyGerudoTrainingGround" | "small_key_gerudo_training_ground" => {
+                Self::SmallKeyGerudoTrainingGround
+            }
+            "SmallKeyGanonsCastle" | "small_key_ganons_castle" => Self::SmallKeyGanonsCastle,
+            "BossKeyForestTemple" | "boss_key_forest_temple" => Self::BossKeyForestTemple,
+            "BossKeyFireTemple" | "boss_key_fire_temple" => Self::BossKeyFireTemple,
+            "BossKeyWaterTemple" | "boss_key_water_temple" => Self::BossKeyWaterTemple,
+            "BossKeyShadowTemple" | "boss_key_shadow_temple" => Self::BossKeyShadowTemple,
+            "BossKeySpiritTemple" | "boss_key_spirit_temple" => Self::BossKeySpiritTemple,
+            "BossKeyGanonsCastle" | "boss_key_ganons_castle" => Self::BossKeyGanonsCastle,
+            // Collectibles
+            "HeartContainer" | "heart_container" => Self::HeartContainer,
+            "PieceOfHeart" | "piece_of_heart" => Self::PieceOfHeart,
+            "GoldSkulltula" | "gold_skulltula" => Self::GoldSkulltula,
+            "SmallMagicJar" | "small_magic_jar" => Self::SmallMagicJar,
+            "LargeMagicJar" | "large_magic_jar" => Self::LargeMagicJar,
+            "RecoveryHeart" | "recovery_heart" => Self::RecoveryHeart,
+            "GreenRupee" | "green_rupee" => Self::GreenRupee,
+            "BlueRupee" | "blue_rupee" => Self::BlueRupee,
+            "RedRupee" | "red_rupee" => Self::RedRupee,
+            "PurpleRupee" | "purple_rupee" => Self::PurpleRupee,
+            "GoldRupee" | "gold_rupee" => Self::GoldRupee,
+            // Special
+            "Triforce" | "triforce" => Self::Triforce,
+            "TriforceOfCourage" | "triforce_of_courage" => Self::TriforceOfCourage,
+            "GanonBossKey" | "ganon_boss_key" => Self::GanonBossKey,
+            _ => return None,
+        };
+        Some(item)
+    }
+
     /// Returns true if this is a progressive item that can be collected multiple times.
     #[must_use]
     pub const fn is_progressive(&self) -> bool {
@@ -271,5 +449,40 @@ mod tests {
         assert!(OotItem::ZeldasLullaby.is_song());
         assert!(OotItem::BoleroOfFire.is_song());
         assert!(!OotItem::Hookshot.is_song());
+    }
+
+    #[test]
+    fn test_by_name_pascal_case() {
+        assert_eq!(OotItem::by_name("MasterSword"), Some(OotItem::MasterSword));
+        assert_eq!(OotItem::by_name("Hookshot"), Some(OotItem::Hookshot));
+        assert_eq!(
+            OotItem::by_name("ForestMedallion"),
+            Some(OotItem::ForestMedallion)
+        );
+        assert_eq!(
+            OotItem::by_name("SmallKeyFireTemple"),
+            Some(OotItem::SmallKeyFireTemple)
+        );
+    }
+
+    #[test]
+    fn test_by_name_snake_case() {
+        assert_eq!(OotItem::by_name("master_sword"), Some(OotItem::MasterSword));
+        assert_eq!(OotItem::by_name("hookshot"), Some(OotItem::Hookshot));
+        assert_eq!(
+            OotItem::by_name("forest_medallion"),
+            Some(OotItem::ForestMedallion)
+        );
+        assert_eq!(
+            OotItem::by_name("small_key_fire_temple"),
+            Some(OotItem::SmallKeyFireTemple)
+        );
+    }
+
+    #[test]
+    fn test_by_name_not_found() {
+        assert_eq!(OotItem::by_name("NotAnItem"), None);
+        assert_eq!(OotItem::by_name(""), None);
+        assert_eq!(OotItem::by_name("invalid_item"), None);
     }
 }

--- a/crate/ootmm/src/lib.rs
+++ b/crate/ootmm/src/lib.rs
@@ -17,3 +17,6 @@ pub mod error;
 pub mod expr;
 pub mod item;
 pub mod region;
+
+// Re-export item types for convenience
+pub use item::{Item, MmItem, OotItem};


### PR DESCRIPTION
## Summary
- Adds combined `Item` enum wrapping `OotItem` and `MmItem`
- Implements `From` traits for conversion
- Adds `by_name` lookup function
- Re-exports from lib.rs

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)