### PR TITLE
feat(ootmm): add serde deserializers for region types (#26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 name = "ootmm"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "serde_yaml",
  "thiserror 2.0.17",
 ]

--- a/crate/ootmm/Cargo.toml
+++ b/crate/ootmm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"
 

--- a/crate/ootmm/src/region.rs
+++ b/crate/ootmm/src/region.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashMap;
 
+use serde::Deserialize;
+
 /// Which game a region belongs to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Game {
     /// Ocarina of Time
     Oot,
@@ -12,7 +15,8 @@ pub enum Game {
 }
 
 /// A game region/area containing locations and exits.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Region {
     /// Unique identifier for this region.
     pub id: String,
@@ -21,10 +25,13 @@ pub struct Region {
     /// Which game this region belongs to.
     pub game: Game,
     /// Locations (item checks) within this region.
+    #[serde(default)]
     pub locations: Vec<Location>,
     /// Exits leading to other regions.
+    #[serde(default)]
     pub exits: Vec<Exit>,
     /// Events that can be triggered in this region.
+    #[serde(default)]
     pub events: Vec<Event>,
 }
 
@@ -59,15 +66,18 @@ impl Region {
 }
 
 /// A specific location (item check) within a region.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Location {
     /// Unique identifier for this location.
     pub id: String,
     /// Human-readable name.
     pub name: String,
     /// The logic expression required to access this location (unparsed).
+    #[serde(default)]
     pub logic: Option<String>,
     /// Type of location (chest, freestanding, NPC, etc.).
+    #[serde(default)]
     pub location_type: LocationType,
 }
 
@@ -96,9 +106,11 @@ impl Location {
 }
 
 /// Types of locations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum LocationType {
     /// Chest containing an item.
+    #[default]
     Chest,
     /// Freestanding item.
     Freestanding,
@@ -127,13 +139,16 @@ pub enum LocationType {
 }
 
 /// An exit connecting one region to another.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Exit {
     /// The target region ID.
     pub target: String,
     /// The logic expression required to use this exit (unparsed).
+    #[serde(default)]
     pub logic: Option<String>,
     /// Type of exit.
+    #[serde(default)]
     pub exit_type: ExitType,
 }
 
@@ -157,9 +172,11 @@ impl Exit {
 }
 
 /// Types of exits between regions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ExitType {
     /// Normal walking/climbing connection.
+    #[default]
     Normal,
     /// One-way drop or ledge.
     OneWay,
@@ -180,13 +197,15 @@ pub enum ExitType {
 }
 
 /// An event that can be triggered in a region.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Event {
     /// Unique identifier for this event.
     pub id: String,
     /// Human-readable name.
     pub name: String,
     /// The logic expression required to trigger this event (unparsed).
+    #[serde(default)]
     pub logic: Option<String>,
 }
 
@@ -210,9 +229,11 @@ impl Event {
 }
 
 /// A world containing all regions for both games.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct World {
     /// All regions indexed by ID.
+    #[serde(default)]
     pub regions: HashMap<String, Region>,
 }
 
@@ -310,5 +331,72 @@ mod tests {
             .with_logic("has(KokiriSword) && has(DekuShield)");
         assert_eq!(event.id, "deku_tree_clear");
         assert!(event.logic.is_some());
+    }
+
+    #[test]
+    fn test_deserialize_region() {
+        let yaml = r#"
+id: "test_region"
+name: "Test Region"
+game: oot
+locations:
+  - id: "test_loc"
+    name: "Test Location"
+"#;
+        let region: Region = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(region.id, "test_region");
+        assert_eq!(region.name, "Test Region");
+        assert_eq!(region.game, Game::Oot);
+        assert_eq!(region.locations.len(), 1);
+        assert_eq!(region.locations[0].name, "Test Location");
+        assert!(region.exits.is_empty());
+        assert!(region.events.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_region_with_exits() {
+        let yaml = r#"
+id: "kokiri_forest"
+name: "Kokiri Forest"
+game: oot
+exits:
+  - target: "lost_woods"
+    exitType: overworld
+  - target: "deku_tree"
+    exitType: dungeon
+    logic: "has(KokiriSword)"
+"#;
+        let region: Region = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(region.exits.len(), 2);
+        assert_eq!(region.exits[0].target, "lost_woods");
+        assert_eq!(region.exits[0].exit_type, ExitType::Overworld);
+        assert_eq!(region.exits[1].exit_type, ExitType::Dungeon);
+        assert_eq!(
+            region.exits[1].logic,
+            Some("has(KokiriSword)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_location_types() {
+        let yaml = r#"
+id: "test"
+name: "Test"
+game: mm
+locations:
+  - id: "chest1"
+    name: "Chest"
+    locationType: chest
+  - id: "npc1"
+    name: "NPC"
+    locationType: npc
+  - id: "gs1"
+    name: "Gossip Stone"
+    locationType: gossipStone
+"#;
+        let region: Region = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(region.locations[0].location_type, LocationType::Chest);
+        assert_eq!(region.locations[1].location_type, LocationType::Npc);
+        assert_eq!(region.locations[2].location_type, LocationType::GossipStone);
     }
 }


### PR DESCRIPTION
## Summary
- Adds serde dependency with derive feature
- Implements Deserialize for all region types
- Adds serde attributes for camelCase field renaming
- Includes 3 deserialization tests (36 tests total)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)