### PR TITLE
docs: revise README for fork clarity and modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,62 @@
+# OOTTracker
+
 [![CI](https://github.com/spencerduncan/oottracker/actions/workflows/ci.yml/badge.svg)](https://github.com/spencerduncan/oottracker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/spencerduncan/oottracker/branch/main/graph/badge.svg)](https://codecov.io/gh/spencerduncan/oottracker)
 
-**Warning:** As of 2021-11-15, [the racing rules](https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules) prohibit all usage of trackers capable of auto-tracking even in manual mode. How exactly this applies to my tracker is unclear pending a decision from the RaceMods.
+> **Note:** This is a fork of [Fenhl's OOTTracker](https://github.com/fenhl/oottracker). The original project and web app are available at <https://oottracker.fenhl.net/>.
 
-This is [Fenhl](https://github.com/fenhl)'s tracker for [the *Ocarina of Time* Item Randomizer](https://ootrandomizer.com/). Current features include:
+An item tracker for [the *Ocarina of Time* Randomizer](https://ootrandomizer.com/).
 
-* Runs on Windows and macOS, also available as [a web app](https://oottracker.fenhl.net/)
-* Support for auto-tracking with [BizHawk](https://tasvideos.org/BizHawk), [Project64](https://www.pj64-emu.com/), or [RetroArch](https://retroarch.com/)
-* Can connect to the networked trackers <https://oot-tracker.web.app/>, <https://ootr-tracker.web.app/>, and <https://ootr-random-settings-tracker.web.app/>
+## Features
 
-# Download
+- **Cross-platform:** Runs on Windows and macOS, with a web interface available
+- **Auto-tracking:** Real-time memory reading from [BizHawk](https://tasvideos.org/BizHawk), [Project64](https://www.pj64-emu.com/), or [RetroArch](https://retroarch.com/)
+- **Networked tracking:** Connect to external trackers including <https://oot-tracker.web.app/>, <https://ootr-tracker.web.app/>, and <https://ootr-random-settings-tracker.web.app/>
+- **Knowledge inference:** Extracts hints from text boxes, dungeon screens, and game state
 
-* [BizHawk (Windows, 64-bit)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-bizhawk-win64.zip)
-* [Project64](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-pj64.js) (requires the Windows app)
-* [Windows (64-bit)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-win64.exe) (includes auto-tracker for RetroArch)
-* [macOS (Universal)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-mac.dmg) (includes auto-tracker for RetroArch)
+## Racing Rules Notice
 
-[Detailed install/usage instructions](https://github.com/fenhl/oottracker/wiki/instructions)
+Please check [the current racing rules](https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules) before using auto-tracking features in races. Rules regarding trackers with auto-tracking capability may apply even when using manual mode.
 
-# Support
+## Download
 
-If you run into any problems, you can:
+For pre-built releases, see the [upstream releases](https://github.com/fenhl/oottracker/releases):
 
-* Ask in #setup-support ([invite link](https://discord.gg/BGRrKKn) • [direct channel link](https://discord.com/channels/274180765816848384/476723801032491008)) on the OoT Randomizer Discord. Feel free to ping `@Fenhl#4813`.
-* [Open an issue](https://github.com/fenhl/oottracker/issues/new). Please search [the existing issues](https://github.com/fenhl/oottracker/issues) first.
+- [BizHawk (Windows, 64-bit)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-bizhawk-win64.zip)
+- [Project64](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-pj64.js) (requires the Windows app)
+- [Windows (64-bit)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-win64.exe) (includes auto-tracker for RetroArch)
+- [macOS (Universal)](https://github.com/fenhl/oottracker/releases/latest/download/oottracker-mac.dmg) (includes auto-tracker for RetroArch)
 
-# Credits
+For detailed install/usage instructions, see the [upstream wiki](https://github.com/fenhl/oottracker/wiki/instructions).
 
-* Big Poe image created for this project by [Maplestar](https://github.com/Maplesstar).
-* Other item images by [Xopar](https://github.com/matthewkirby), used with permission.
-* Some game data sourced from [the CloudModding wiki](https://wiki.cloudmodding.com/oot) and [RiptideSage's completed checks script](https://github.com/RiptideSage/OoT-CompletedChecks). For my own research, I use [BizHawk](https://tasvideos.org/BizHawk) and [the practice rom](https://www.practicerom.com/).
+## Building from Source
+
+```bash
+# Build all crates
+cargo build --workspace
+
+# Build for release
+cargo build --release
+
+# Run the GUI application
+cargo run --package oottracker-gui
+
+# Run the web server locally
+cargo run --package oottracker-web
+```
+
+## Support
+
+If you run into problems:
+
+- Ask in #setup-support ([invite link](https://discord.gg/BGRrKKn) • [direct channel link](https://discord.com/channels/274180765816848384/476723801032491008)) on the OoT Randomizer Discord
+- [Open an issue](https://github.com/spencerduncan/oottracker/issues) on this fork
+- For upstream issues, see [Fenhl's issue tracker](https://github.com/fenhl/oottracker/issues)
+
+## Credits
+
+- Original project by [Fenhl](https://github.com/fenhl)
+- Big Poe image by [Maplestar](https://github.com/Maplesstar)
+- Item images by [Xopar](https://github.com/matthewkirby), used with permission
+- Game data from [the CloudModding wiki](https://wiki.cloudmodding.com/oot) and [RiptideSage's completed checks script](https://github.com/RiptideSage/OoT-CompletedChecks)
+- Research tools: [BizHawk](https://tasvideos.org/BizHawk) and [the practice rom](https://www.practicerom.com/)


### PR DESCRIPTION
- Add clear fork attribution to Fenhl's original project
- Update racing rules notice to be evergreen (remove outdated 2021 date)
- Add "Building from Source" section with cargo commands
- Add "Knowledge inference" as a feature highlight
- Update Support section to reference both fork and upstream issues
- Credit Fenhl as original project author
- Improve overall structure and formatting