### PR TITLE
test(ootmm): add lexer tokenization tests

### DIFF
--- a/crate/ootmm/src/expr/lexer.rs
+++ b/crate/ootmm/src/expr/lexer.rs
@@ -222,4 +222,309 @@ mod tests {
             Err(LexError::UnexpectedChar('@', 0))
         ));
     }
+
+    // ===== Additional tests for comprehensive coverage =====
+
+    #[test]
+    fn test_whitespace_handling_tabs() {
+        let mut lexer = Lexer::new("true\t\tfalse");
+        assert_eq!(lexer.next_token().unwrap(), Token::True);
+        assert_eq!(lexer.next_token().unwrap(), Token::False);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_whitespace_handling_newlines() {
+        let mut lexer = Lexer::new("true\n\nfalse");
+        assert_eq!(lexer.next_token().unwrap(), Token::True);
+        assert_eq!(lexer.next_token().unwrap(), Token::False);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_whitespace_handling_mixed() {
+        let mut lexer = Lexer::new("  true \t\n  false  ");
+        assert_eq!(lexer.next_token().unwrap(), Token::True);
+        assert_eq!(lexer.next_token().unwrap(), Token::False);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_multiple_eof_calls() {
+        let mut lexer = Lexer::new("x");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("x".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_single_lparen() {
+        let mut lexer = Lexer::new("(");
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_single_rparen() {
+        let mut lexer = Lexer::new(")");
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_identifier_with_underscore_prefix() {
+        let mut lexer = Lexer::new("_private _internal__value");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("_private".into()));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("_internal__value".into())
+        );
+    }
+
+    #[test]
+    fn test_identifier_with_numbers() {
+        let mut lexer = Lexer::new("item1 var2name test_123_abc");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("item1".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("var2name".into()));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("test_123_abc".into())
+        );
+    }
+
+    #[test]
+    fn test_keywords_are_case_sensitive() {
+        let mut lexer = Lexer::new("True FALSE True123");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("True".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("FALSE".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("True123".into()));
+    }
+
+    #[test]
+    fn test_number_zero() {
+        let mut lexer = Lexer::new("0");
+        assert_eq!(lexer.next_token().unwrap(), Token::Number(0));
+    }
+
+    #[test]
+    fn test_number_single_digit() {
+        let mut lexer = Lexer::new("7");
+        assert_eq!(lexer.next_token().unwrap(), Token::Number(7));
+    }
+
+    #[test]
+    fn test_number_large() {
+        let mut lexer = Lexer::new("9999999999");
+        assert_eq!(lexer.next_token().unwrap(), Token::Number(9999999999));
+    }
+
+    #[test]
+    fn test_empty_string_literal() {
+        let mut lexer = Lexer::new("\"\"");
+        assert_eq!(lexer.next_token().unwrap(), Token::String("".into()));
+    }
+
+    #[test]
+    fn test_string_with_spaces() {
+        let mut lexer = Lexer::new("\"hello world\"");
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::String("hello world".into())
+        );
+    }
+
+    #[test]
+    fn test_string_with_special_chars() {
+        let mut lexer = Lexer::new("\"a && b || !c\"");
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::String("a && b || !c".into())
+        );
+    }
+
+    #[test]
+    fn test_unexpected_char_single_ampersand() {
+        let mut lexer = Lexer::new("&");
+        assert!(matches!(
+            lexer.next_token(),
+            Err(LexError::UnexpectedChar('&', 0))
+        ));
+    }
+
+    #[test]
+    fn test_unexpected_char_single_pipe() {
+        let mut lexer = Lexer::new("|");
+        assert!(matches!(
+            lexer.next_token(),
+            Err(LexError::UnexpectedChar('|', 0))
+        ));
+    }
+
+    #[test]
+    fn test_nested_parentheses() {
+        let mut lexer = Lexer::new("((()))");
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_consecutive_tokens_no_spaces() {
+        let mut lexer = Lexer::new("a&&b||!c");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("a".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("b".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Not);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("c".into()));
+    }
+
+    #[test]
+    fn test_error_position_tracking() {
+        let mut lexer = Lexer::new("abc @");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("abc".into()));
+        let err = lexer.next_token().unwrap_err();
+        assert!(matches!(err, LexError::UnexpectedChar('@', 4)));
+    }
+
+    #[test]
+    fn test_unterminated_string_position() {
+        let mut lexer = Lexer::new("abc \"unterminated");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("abc".into()));
+        let err = lexer.next_token().unwrap_err();
+        assert!(matches!(err, LexError::UnterminatedString(4)));
+    }
+
+    #[test]
+    fn test_all_token_types_combined() {
+        let mut lexer = Lexer::new("func(true, false, 42, \"str\", x) && !y || z");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("func".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::True);
+        assert_eq!(lexer.next_token().unwrap(), Token::Comma);
+        assert_eq!(lexer.next_token().unwrap(), Token::False);
+        assert_eq!(lexer.next_token().unwrap(), Token::Comma);
+        assert_eq!(lexer.next_token().unwrap(), Token::Number(42));
+        assert_eq!(lexer.next_token().unwrap(), Token::Comma);
+        assert_eq!(lexer.next_token().unwrap(), Token::String("str".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Comma);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("x".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Not);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("y".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("z".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_function_call_multiple_args() {
+        let mut lexer = Lexer::new("between(DAY1_AM_6_00, DAY1_PM_6_00)");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("between".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("DAY1_AM_6_00".into())
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Comma);
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("DAY1_PM_6_00".into())
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+    }
+
+    #[test]
+    fn test_chained_and_operators() {
+        let mut lexer = Lexer::new("a && b && c && d");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("a".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("b".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("c".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("d".into()));
+    }
+
+    #[test]
+    fn test_chained_or_operators() {
+        let mut lexer = Lexer::new("x || y || z");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("x".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("y".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("z".into()));
+    }
+
+    #[test]
+    fn test_not_with_parentheses() {
+        let mut lexer = Lexer::new("!(a && b)");
+        assert_eq!(lexer.next_token().unwrap(), Token::Not);
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("a".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("b".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+    }
+
+    #[test]
+    fn test_string_with_numbers() {
+        let mut lexer = Lexer::new("\"123 abc 456\"");
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::String("123 abc 456".into())
+        );
+    }
+
+    #[test]
+    fn test_identifier_prefix_matches_keyword() {
+        let mut lexer = Lexer::new("truthy falsey");
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("truthy".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("falsey".into()));
+    }
+
+    #[test]
+    fn test_only_whitespace() {
+        let mut lexer = Lexer::new("   \t\n   ");
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
+
+    #[test]
+    fn test_complex_nested_expression() {
+        let mut lexer =
+            Lexer::new("(has(SWORD) && (is_adult || has(SLINGSHOT))) || event(BOSS_DEFEATED)");
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("has".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("SWORD".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::And);
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("is_adult".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("has".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("SLINGSHOT".into())
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Or);
+        assert_eq!(lexer.next_token().unwrap(), Token::Ident("event".into()));
+        assert_eq!(lexer.next_token().unwrap(), Token::LParen);
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Ident("BOSS_DEFEATED".into())
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::RParen);
+        assert_eq!(lexer.next_token().unwrap(), Token::Eof);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 30 new tests for lexer tokenization
- Total test count now 40 for lexer
- Tests operators, identifiers, keywords, and edge cases

Closes #83

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)