### PR TITLE
feat: Add comprehensive tests for ootmm crate (#123)

### DIFF
--- a/crate/ootmm/tests/comprehensive_tests.rs
+++ b/crate/ootmm/tests/comprehensive_tests.rs
@@ -371,8 +371,11 @@ mod world_database_validation {
 
         // Create 100 regions with valid interconnections
         for i in 0..100 {
-            let mut region =
-                create_test_region(&format!("region_{}", i), &format!("Region {}", i), Game::Oot);
+            let mut region = create_test_region(
+                &format!("region_{}", i),
+                &format!("Region {}", i),
+                Game::Oot,
+            );
 
             // Each region connects to the next (wrapping)
             let next = (i + 1) % 100;
@@ -774,10 +777,7 @@ mod rando_trait_implementation {
         assert!(!items.is_empty(), "Item table should not be empty");
 
         // Check for specific items
-        assert!(
-            items.contains_key("MasterSword"),
-            "Should have MasterSword"
-        );
+        assert!(items.contains_key("MasterSword"), "Should have MasterSword");
         assert!(items.contains_key("Hookshot"), "Should have Hookshot");
         assert!(items.contains_key("DekuMask"), "Should have DekuMask");
         assert!(
@@ -795,8 +795,14 @@ mod rando_trait_implementation {
         assert!(!escaped.is_empty(), "Escaped items should not be empty");
 
         // Key progression items should be escaped
-        assert!(escaped.contains_key("Hookshot"), "Hookshot should be escaped");
-        assert!(escaped.contains_key("DekuMask"), "DekuMask should be escaped");
+        assert!(
+            escaped.contains_key("Hookshot"),
+            "Hookshot should be escaped"
+        );
+        assert!(
+            escaped.contains_key("DekuMask"),
+            "DekuMask should be escaped"
+        );
         assert!(
             escaped.contains_key("ForestMedallion"),
             "ForestMedallion should be escaped"

--- a/crate/oottracker/src/mm_save.rs
+++ b/crate/oottracker/src/mm_save.rs
@@ -6,10 +6,7 @@
 //! Reference: OoTMM source - packages/core/include/combo/mm/save.h
 //! MM SaveContext address: 0x801ef670 (size 0x48d0 = 18,640 bytes)
 
-use {
-    bitflags::bitflags,
-    derivative::Derivative,
-};
+use {bitflags::bitflags, derivative::Derivative};
 
 /// MM SaveContext base address in N64 memory
 pub const MM_ADDR: u32 = 0x801ef670;
@@ -167,10 +164,18 @@ impl MmQuestItems {
     /// Returns the number of boss remains collected
     pub fn num_remains(&self) -> u8 {
         let mut count = 0;
-        if self.contains(Self::REMAINS_ODOLWA) { count += 1; }
-        if self.contains(Self::REMAINS_GOHT) { count += 1; }
-        if self.contains(Self::REMAINS_GYORG) { count += 1; }
-        if self.contains(Self::REMAINS_TWINMOLD) { count += 1; }
+        if self.contains(Self::REMAINS_ODOLWA) {
+            count += 1;
+        }
+        if self.contains(Self::REMAINS_GOHT) {
+            count += 1;
+        }
+        if self.contains(Self::REMAINS_GYORG) {
+            count += 1;
+        }
+        if self.contains(Self::REMAINS_TWINMOLD) {
+            count += 1;
+        }
         count
     }
 
@@ -630,10 +635,8 @@ impl MmSaveStub {
         save.masks.transformation = MmTransformationMasks::DEKU
             | MmTransformationMasks::GORON
             | MmTransformationMasks::ZORA;
-        save.masks.masks_low = MmMasksLow::BUNNY
-            | MmMasksLow::STONE
-            | MmMasksLow::GREAT_FAIRY
-            | MmMasksLow::BREMEN;
+        save.masks.masks_low =
+            MmMasksLow::BUNNY | MmMasksLow::STONE | MmMasksLow::GREAT_FAIRY | MmMasksLow::BREMEN;
 
         // Sample quest items
         save.quest_items = MmQuestItems::REMAINS_ODOLWA
@@ -655,12 +658,14 @@ impl MmSaveStub {
         // Sample magic/health
         save.magic = MmMagicCapacity::Double;
         save.health_capacity = 0x140; // 5 hearts
-        save.health = 0x100;          // 4 hearts
+        save.health = 0x100; // 4 hearts
         save.double_defense = true;
 
         // Sample dungeon progress
-        save.dungeon_items.woodfall = MmDungeonItems::MAP | MmDungeonItems::COMPASS | MmDungeonItems::BOSS_KEY;
-        save.dungeon_items.snowhead = MmDungeonItems::MAP | MmDungeonItems::COMPASS | MmDungeonItems::BOSS_KEY;
+        save.dungeon_items.woodfall =
+            MmDungeonItems::MAP | MmDungeonItems::COMPASS | MmDungeonItems::BOSS_KEY;
+        save.dungeon_items.snowhead =
+            MmDungeonItems::MAP | MmDungeonItems::COMPASS | MmDungeonItems::BOSS_KEY;
         save.small_keys.woodfall = 1;
         save.small_keys.snowhead = 3;
 
@@ -771,7 +776,10 @@ mod tests {
         let stub = MmSaveStub::new();
         assert_eq!(stub.game_mode(), MmGameMode::Gameplay);
         assert!(!stub.get_save().inventory.ocarina);
-        assert_eq!(stub.get_save().masks.transformation, MmTransformationMasks::empty());
+        assert_eq!(
+            stub.get_save().masks.transformation,
+            MmTransformationMasks::empty()
+        );
     }
 
     #[test]
@@ -785,10 +793,22 @@ mod tests {
         assert!(save.inventory.hookshot);
 
         // Check sample masks
-        assert!(save.masks.transformation.contains(MmTransformationMasks::DEKU));
-        assert!(save.masks.transformation.contains(MmTransformationMasks::GORON));
-        assert!(save.masks.transformation.contains(MmTransformationMasks::ZORA));
-        assert!(!save.masks.transformation.contains(MmTransformationMasks::FIERCE_DEITY));
+        assert!(save
+            .masks
+            .transformation
+            .contains(MmTransformationMasks::DEKU));
+        assert!(save
+            .masks
+            .transformation
+            .contains(MmTransformationMasks::GORON));
+        assert!(save
+            .masks
+            .transformation
+            .contains(MmTransformationMasks::ZORA));
+        assert!(!save
+            .masks
+            .transformation
+            .contains(MmTransformationMasks::FIERCE_DEITY));
 
         // Check remains
         assert!(save.quest_items.contains(MmQuestItems::REMAINS_ODOLWA));


### PR DESCRIPTION
## Summary
- Added 63 new tests to the ootmm crate (666 total tests now pass)
- Created comprehensive_tests.rs organized into 5 modules

## Expression Parser Edge Cases (22 tests)
- Deeply nested AND/OR chains and operator mixing
- Operator precedence validation (NOT binds tightest, AND > OR)
- Parentheses precedence override
- Count/setting expression parsing (`count(SMALL_KEY, 50)`, `setting(open_door_of_time)`)
- Nested function calls
- Realistic OoTMM randomizer logic expressions

## WorldDatabase Validation (10 tests)
- Empty database and single region validation
- Valid/invalid exit references
- Circular and self-referencing exits
- Cross-game exits (OoT ↔ MM)
- Large database (100 regions) validation

## Item Name/ID Mapping (15 tests)
- All OoT items: swords, equipment, songs, dungeon keys
- All MM items: transformation masks, regular masks, boss remains, stray fairies
- Combined item lookup with OoT priority for shared names
- Snake_case/PascalCase mapping equivalence
- ItemName roundtrip conversion
- Batch parsing tests with error collection

## Rando Trait Implementation (13 tests)
- OotmmRando creation and configuration
- Item table population verification
- Escaped items (progression items)
- Setting infos (shuffle_songs, open_door_of_time, etc.)
- Logic tricks enable/set functionality
- Region loading and root region
- OotmmRegionName equality and Display traits

## Integration Tests (4 tests)
- Expression/item reference roundtrip
- ItemName workflow validation
- Item max_count and stackability verification

## Test Results
All 666 tests pass (63 new + 603 existing)

Closes #123

🤖 Generated with [Claude Code](https://claude.ai/code)