### PR TITLE
test: Add E2E tracker session test

### DIFF
--- a/crate/ootmm/tests/e2e_tracker_session.rs
+++ b/crate/ootmm/tests/e2e_tracker_session.rs
@@ -338,7 +338,10 @@ fn test_e2e_progressive_item_collection() {
 
     // Stage 1: Empty state
     let stage1 = session.count_accessible_locations();
-    assert_eq!(stage1, 3, "Stage 1 (empty): Should have 3 accessible locations");
+    assert_eq!(
+        stage1, 3,
+        "Stage 1 (empty): Should have 3 accessible locations"
+    );
 
     // Stage 2: Add Kokiri Sword
     session.add_item("KOKIRISWORD");
@@ -529,7 +532,10 @@ regions:
     // Default is child
     session.set_age(Age::Child);
     let child_accessible = session.count_accessible_locations();
-    assert_eq!(child_accessible, 1, "Child should access 1 location initially");
+    assert_eq!(
+        child_accessible, 1,
+        "Child should access 1 location initially"
+    );
 
     // Add slingshot as child
     session.add_item("SLINGSHOT");
@@ -542,7 +548,10 @@ regions:
     // Switch to adult
     session.set_age(Age::Adult);
     let adult_accessible = session.count_accessible_locations();
-    assert_eq!(adult_accessible, 1, "Adult should access 1 location initially");
+    assert_eq!(
+        adult_accessible, 1,
+        "Adult should access 1 location initially"
+    );
 
     // Add hookshot as adult
     session.add_item("HOOKSHOT");


### PR DESCRIPTION
## Summary
- Add end-to-end test simulating a full tracker session
- Tests game progression: start → collect items → verify accessibility increases

## Test Scenarios
1. **Starting state** - Count accessible locations with empty inventory
2. **Basic items** - Add KokiriSword + DekuShield, verify more locations accessible
3. **Dungeon items** - Add Slingshot, verify even more accessible
4. **Progression validation** - Ensure accessibility monotonically increases

## Test plan
- [x] E2E test passes
- [x] Demonstrates item progression unlocking locations

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)