### PR TITLE
feat: Add ootmm crate as dependency to oottracker (#145)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "image 0.24.6",
  "itertools 0.10.5",
  "once_cell",
+ "ootmm",
  "ootr",
  "ootr-static",
  "oottracker-derive",

--- a/crate/oottracker/Cargo.toml
+++ b/crate/oottracker/Cargo.toml
@@ -51,6 +51,9 @@ path = "../ootr"
 [dependencies.ootr-static] # used in tests
 path = "../ootr-static"
 
+[dependencies.ootmm]
+path = "../ootmm"
+
 [dependencies.oottracker-derive]
 path = "../oottracker-derive"
 

--- a/crate/oottracker/src/lib.rs
+++ b/crate/oottracker/src/lib.rs
@@ -31,6 +31,8 @@ use {
     std::ops::{AddAssign, Sub},
 };
 
+use ootmm as _; // Dependency added for future MM integration
+
 pub mod checks;
 pub mod ctx;
 #[cfg(feature = "firebase")]


### PR DESCRIPTION
## Summary
- Add ootmm crate as a dependency to oottracker
- Add `use ootmm as _;` to satisfy unused_crate_dependencies lint

## Test plan
- [x] cargo build -p oottracker succeeds
- [x] cargo fmt (no changes needed)

Closes #145

🤖 Generated with [Claude Code](https://claude.ai/code)