### PR TITLE
test: Check item values not just key existence (#241)

### DIFF
--- a/crate/ootmm/src/rando.rs
+++ b/crate/ootmm/src/rando.rs
@@ -695,11 +695,17 @@ mod tests {
         let rando = OotmmRando::new().unwrap();
         let items = rando.item_table().unwrap();
 
-        // Should have items from both games
-        assert!(items.contains_key("MasterSword"));
-        assert!(items.contains_key("Hookshot"));
-        assert!(items.contains_key("DekuMask"));
-        assert!(items.contains_key("OdolwaRemains"));
+        // Should have items from both games with correct values
+        assert_eq!(
+            items.get("MasterSword").map(|i| i.name()),
+            Some("MasterSword")
+        );
+        assert_eq!(items.get("Hookshot").map(|i| i.name()), Some("Hookshot"));
+        assert_eq!(items.get("DekuMask").map(|i| i.name()), Some("DekuMask"));
+        assert_eq!(
+            items.get("OdolwaRemains").map(|i| i.name()),
+            Some("OdolwaRemains")
+        );
     }
 
     #[test]
@@ -707,10 +713,13 @@ mod tests {
         let rando = OotmmRando::new().unwrap();
         let escaped = rando.escaped_items().unwrap();
 
-        // Should contain major progression items
-        assert!(escaped.contains_key("Hookshot"));
-        assert!(escaped.contains_key("DekuMask"));
-        assert!(escaped.contains_key("ForestMedallion"));
+        // Should contain major progression items with correct values
+        assert_eq!(escaped.get("Hookshot").map(|i| i.name()), Some("Hookshot"));
+        assert_eq!(escaped.get("DekuMask").map(|i| i.name()), Some("DekuMask"));
+        assert_eq!(
+            escaped.get("ForestMedallion").map(|i| i.name()),
+            Some("ForestMedallion")
+        );
     }
 
     #[test]

--- a/crate/ootmm/tests/comprehensive_tests.rs
+++ b/crate/ootmm/tests/comprehensive_tests.rs
@@ -776,13 +776,26 @@ mod rando_trait_implementation {
         // Should have items from both games
         assert!(!items.is_empty(), "Item table should not be empty");
 
-        // Check for specific items
-        assert!(items.contains_key("MasterSword"), "Should have MasterSword");
-        assert!(items.contains_key("Hookshot"), "Should have Hookshot");
-        assert!(items.contains_key("DekuMask"), "Should have DekuMask");
-        assert!(
-            items.contains_key("OdolwaRemains"),
-            "Should have OdolwaRemains"
+        // Check for specific items and verify their values
+        assert_eq!(
+            items.get("MasterSword").map(|i| i.name()),
+            Some("MasterSword"),
+            "Should have MasterSword with correct value"
+        );
+        assert_eq!(
+            items.get("Hookshot").map(|i| i.name()),
+            Some("Hookshot"),
+            "Should have Hookshot with correct value"
+        );
+        assert_eq!(
+            items.get("DekuMask").map(|i| i.name()),
+            Some("DekuMask"),
+            "Should have DekuMask with correct value"
+        );
+        assert_eq!(
+            items.get("OdolwaRemains").map(|i| i.name()),
+            Some("OdolwaRemains"),
+            "Should have OdolwaRemains with correct value"
         );
     }
 
@@ -794,22 +807,26 @@ mod rando_trait_implementation {
         // Should contain major progression items
         assert!(!escaped.is_empty(), "Escaped items should not be empty");
 
-        // Key progression items should be escaped
-        assert!(
-            escaped.contains_key("Hookshot"),
-            "Hookshot should be escaped"
+        // Key progression items should be escaped with correct values
+        assert_eq!(
+            escaped.get("Hookshot").map(|i| i.name()),
+            Some("Hookshot"),
+            "Hookshot should be escaped with correct value"
         );
-        assert!(
-            escaped.contains_key("DekuMask"),
-            "DekuMask should be escaped"
+        assert_eq!(
+            escaped.get("DekuMask").map(|i| i.name()),
+            Some("DekuMask"),
+            "DekuMask should be escaped with correct value"
         );
-        assert!(
-            escaped.contains_key("ForestMedallion"),
-            "ForestMedallion should be escaped"
+        assert_eq!(
+            escaped.get("ForestMedallion").map(|i| i.name()),
+            Some("ForestMedallion"),
+            "ForestMedallion should be escaped with correct value"
         );
-        assert!(
-            escaped.contains_key("OdolwaRemains"),
-            "OdolwaRemains should be escaped"
+        assert_eq!(
+            escaped.get("OdolwaRemains").map(|i| i.name()),
+            Some("OdolwaRemains"),
+            "OdolwaRemains should be escaped with correct value"
         );
     }
 


### PR DESCRIPTION
## Summary
- Updated tests to verify actual values, not just key existence
- 4 assertions improved across 2 files

## Test plan
- [x] All 666 tests pass
- [x] cargo fmt && cargo clippy clean

Closes #241

🤖 Generated with [Claude Code](https://claude.ai/code)