### PR TITLE
test: Remove trivial Debug/Display format tests (#242)

### DIFF
--- a/crate/ootmm/src/expr/context.rs
+++ b/crate/ootmm/src/expr/context.rs
@@ -879,17 +879,4 @@ mod tests {
         assert_eq!(ctx2.get_item("HOOKSHOT"), 1);
         assert!(ctx2.is_adult());
     }
-
-    #[test]
-    fn test_context_debug() {
-        let ctx = GameContext::new();
-        let debug_str = format!("{:?}", ctx);
-        assert!(debug_str.contains("GameContext"));
-    }
-
-    #[test]
-    fn test_age_debug() {
-        assert_eq!(format!("{:?}", Age::Adult), "Adult");
-        assert_eq!(format!("{:?}", Age::Child), "Child");
-    }
 }

--- a/crate/ootmm/src/item.rs
+++ b/crate/ootmm/src/item.rs
@@ -612,12 +612,6 @@ mod tests {
     // ===== GAME ENUM TESTS =====
 
     #[test]
-    fn test_game_enum_debug() {
-        assert_eq!(format!("{:?}", Game::OcarinaOfTime), "OcarinaOfTime");
-        assert_eq!(format!("{:?}", Game::MajorasMask), "MajorasMask");
-    }
-
-    #[test]
     fn test_game_enum_equality() {
         assert_eq!(Game::OcarinaOfTime, Game::OcarinaOfTime);
         assert_eq!(Game::MajorasMask, Game::MajorasMask);
@@ -635,16 +629,6 @@ mod tests {
     }
 
     // ===== ITEM CATEGORY TESTS =====
-
-    #[test]
-    fn test_item_category_debug() {
-        assert_eq!(format!("{:?}", ItemCategory::Sword), "Sword");
-        assert_eq!(
-            format!("{:?}", ItemCategory::TransformationMask),
-            "TransformationMask"
-        );
-        assert_eq!(format!("{:?}", ItemCategory::Equipment), "Equipment");
-    }
 
     #[test]
     fn test_item_category_equality() {

--- a/crate/ootmm/tests/expression_tests.rs
+++ b/crate/ootmm/tests/expression_tests.rs
@@ -248,15 +248,4 @@ mod items {
         assert!(Item::by_name("deku_mask").is_some());
         assert!(Item::by_name("fierce_deity_mask").is_some());
     }
-
-    #[test]
-    fn test_item_display_for_expressions() {
-        // Ensure items can be displayed in expressions
-        let oot = OotItem::Hookshot;
-        let mm = MmItem::DekuMask;
-
-        // These should be usable in expressions like has(HOOKSHOT)
-        assert!(!format!("{:?}", oot).is_empty());
-        assert!(!format!("{:?}", mm).is_empty());
-    }
 }

--- a/crate/ootr/src/check.rs
+++ b/crate/ootr/src/check.rs
@@ -216,67 +216,6 @@ mod tests {
     }
 
     #[test]
-    fn display_mq_all_dungeons() {
-        // Test MQ display for main dungeons
-        let main_dungeons = [
-            (MainDungeon::DekuTree, "is Deku Tree MQ or vanilla"),
-            (
-                MainDungeon::DodongosCavern,
-                "is Dodongo's Cavern MQ or vanilla",
-            ),
-            (MainDungeon::JabuJabu, "is Jabu-Jabu MQ or vanilla"),
-            (MainDungeon::ForestTemple, "is Forest Temple MQ or vanilla"),
-            (MainDungeon::FireTemple, "is Fire Temple MQ or vanilla"),
-            (MainDungeon::WaterTemple, "is Water Temple MQ or vanilla"),
-            (MainDungeon::ShadowTemple, "is Shadow Temple MQ or vanilla"),
-            (MainDungeon::SpiritTemple, "is Spirit Temple MQ or vanilla"),
-        ];
-
-        for (dungeon, expected) in &main_dungeons {
-            let check: Check<MockRando> = Check::Mq(Dungeon::Main(*dungeon));
-            assert_eq!(format!("{}", check), *expected);
-        }
-    }
-
-    #[test]
-    fn display_mq_mini_dungeons() {
-        let mini_dungeons = [
-            (Dungeon::IceCavern, "is Ice Cavern MQ or vanilla"),
-            (
-                Dungeon::BottomOfTheWell,
-                "is Bottom of the Well MQ or vanilla",
-            ),
-            (
-                Dungeon::GerudoTrainingGround,
-                "is Gerudo Training Ground MQ or vanilla",
-            ),
-            (Dungeon::GanonsCastle, "is Ganon's Castle MQ or vanilla"),
-        ];
-
-        for (dungeon, expected) in &mini_dungeons {
-            let check: Check<MockRando> = Check::Mq(*dungeon);
-            assert_eq!(format!("{}", check), *expected);
-        }
-    }
-
-    #[test]
-    fn display_trial_active_all_medallions() {
-        let medallions = [
-            (Medallion::Light, "Light trial active"),
-            (Medallion::Forest, "Forest trial active"),
-            (Medallion::Fire, "Fire trial active"),
-            (Medallion::Water, "Water trial active"),
-            (Medallion::Shadow, "Shadow trial active"),
-            (Medallion::Spirit, "Spirit trial active"),
-        ];
-
-        for (medallion, expected) in &medallions {
-            let check: Check<MockRando> = Check::TrialActive(*medallion);
-            assert_eq!(format!("{}", check), *expected);
-        }
-    }
-
-    #[test]
     fn check_equality() {
         let check1: Check<MockRando> = Check::Event("test".to_string());
         let check2: Check<MockRando> = Check::Event("test".to_string());
@@ -313,57 +252,5 @@ mod tests {
         let cloned = original.clone();
 
         assert_eq!(original, cloned);
-    }
-
-    #[test]
-    fn display_exit_with_empty_region_names() {
-        let check: Check<MockRando> = Check::Exit {
-            from: "".to_string(),
-            from_mq: None,
-            to: "".to_string(),
-        };
-        assert_eq!(format!("{}", check), " (overworld) → ");
-    }
-
-    #[test]
-    fn display_location_with_special_characters() {
-        let check: Check<MockRando> = Check::Location("KF Mido's Top Left Chest".to_string());
-        assert_eq!(format!("{}", check), "KF Mido's Top Left Chest");
-    }
-
-    #[test]
-    fn display_event_with_spaces() {
-        let check: Check<MockRando> =
-            Check::Event("Forest Temple Boss Key Door Opened".to_string());
-        assert_eq!(
-            format!("{}", check),
-            "event: Forest Temple Boss Key Door Opened"
-        );
-    }
-
-    #[test]
-    fn display_setting_with_underscores() {
-        let check: Check<MockRando> = Check::Setting("shuffle_interior_entrances".to_string());
-        assert_eq!(format!("{}", check), "setting: shuffle_interior_entrances");
-    }
-
-    #[test]
-    fn display_trick_with_underscores() {
-        let check: Check<MockRando> = Check::Trick("logic_dc_jump".to_string());
-        assert_eq!(format!("{}", check), "trick: logic_dc_jump");
-    }
-
-    #[test]
-    fn display_logic_helper_with_underscores() {
-        let check: Check<MockRando> = Check::LogicHelper("can_blast_or_smash".to_string());
-        assert_eq!(format!("{}", check), "logic helper \"can_blast_or_smash\"");
-    }
-
-    #[test]
-    fn check_debug_format() {
-        let check: Check<MockRando> = Check::Event("test".to_string());
-        let debug_str = format!("{:?}", check);
-        assert!(debug_str.contains("Event"));
-        assert!(debug_str.contains("test"));
     }
 }

--- a/crate/ootr/src/region.rs
+++ b/crate/ootr/src/region.rs
@@ -384,12 +384,6 @@ mod tests {
     }
 
     #[test]
-    fn test_mq_debug() {
-        assert_eq!(format!("{:?}", Mq::Vanilla), "Vanilla");
-        assert_eq!(format!("{:?}", Mq::Mq), "Mq");
-    }
-
-    #[test]
     fn test_region_with_dungeon_context() {
         use crate::model::MainDungeon;
         use mock::{MockRando, MockRegionName};


### PR DESCRIPTION
## Summary
- Removed 159 lines of trivial format tests across 5 files
- Kept representative Display tests and behavior tests

## Test plan
- [x] All tests pass
- [x] cargo fmt && cargo clippy clean

Closes #242

🤖 Generated with [Claude Code](https://claude.ai/code)