### PR TITLE
test: Add semantic equivalence tests for roundtrip operations (#245)

### DIFF
--- a/crate/ootmm/src/item.rs
+++ b/crate/ootmm/src/item.rs
@@ -671,4 +671,308 @@ mod tests {
         set.insert(ItemCategory::Sword); // duplicate
         assert_eq!(set.len(), 2);
     }
+
+    // ===== SEMANTIC EQUIVALENCE ROUNDTRIP TESTS =====
+    //
+    // These tests verify that roundtripped items preserve semantic properties,
+    // not just structural equality. An item should behave identically after
+    // serialization/deserialization.
+
+    /// Helper to verify semantic equivalence of OoT items after serde roundtrip.
+    fn verify_oot_item_semantic_roundtrip(item: OotItem) {
+        let serialized = serde_yaml::to_string(&item).unwrap();
+        let deserialized: OotItem = serde_yaml::from_str(&serialized).unwrap();
+
+        // Structural check
+        assert_eq!(
+            item, deserialized,
+            "structural equality failed for {:?}",
+            item
+        );
+
+        // Semantic checks - verify all functional properties are preserved
+        assert_eq!(
+            item.category(),
+            deserialized.category(),
+            "category mismatch for {:?}",
+            item
+        );
+        assert_eq!(
+            item.max_count(),
+            deserialized.max_count(),
+            "max_count mismatch for {:?}",
+            item
+        );
+    }
+
+    /// Helper to verify semantic equivalence of MM items after serde roundtrip.
+    fn verify_mm_item_semantic_roundtrip(item: MmItem) {
+        let serialized = serde_yaml::to_string(&item).unwrap();
+        let deserialized: MmItem = serde_yaml::from_str(&serialized).unwrap();
+
+        // Structural check
+        assert_eq!(
+            item, deserialized,
+            "structural equality failed for {:?}",
+            item
+        );
+
+        // Semantic checks - verify all functional properties are preserved
+        assert_eq!(
+            item.category(),
+            deserialized.category(),
+            "category mismatch for {:?}",
+            item
+        );
+        assert_eq!(
+            item.max_count(),
+            deserialized.max_count(),
+            "max_count mismatch for {:?}",
+            item
+        );
+    }
+
+    /// Helper to verify semantic equivalence of combined Item after serde roundtrip.
+    fn verify_combined_item_semantic_roundtrip(item: Item) {
+        let serialized = serde_yaml::to_string(&item).unwrap();
+        let deserialized: Item = serde_yaml::from_str(&serialized).unwrap();
+
+        // Structural check
+        assert_eq!(
+            item, deserialized,
+            "structural equality failed for {:?}",
+            item
+        );
+
+        // Semantic checks - verify all functional properties are preserved
+        assert_eq!(
+            item.category(),
+            deserialized.category(),
+            "category mismatch for {:?}",
+            item
+        );
+        assert_eq!(
+            item.max_count(),
+            deserialized.max_count(),
+            "max_count mismatch for {:?}",
+            item
+        );
+        assert_eq!(
+            item.game(),
+            deserialized.game(),
+            "game mismatch for {:?}",
+            item
+        );
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_oot_swords() {
+        for item in [
+            OotItem::KokiriSword,
+            OotItem::MasterSword,
+            OotItem::BiggoronSword,
+            OotItem::GiantKnife,
+        ] {
+            verify_oot_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_oot_equipment() {
+        for item in [
+            OotItem::Hookshot,
+            OotItem::Longshot,
+            OotItem::Boomerang,
+            OotItem::Bow,
+            OotItem::MegatonHammer,
+            OotItem::LensOfTruth,
+            OotItem::Slingshot,
+        ] {
+            verify_oot_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_oot_songs() {
+        for item in [
+            OotItem::ZeldasLullaby,
+            OotItem::EponasSong,
+            OotItem::SariasSong,
+            OotItem::SongOfTime,
+            OotItem::BoleroOfFire,
+            OotItem::PreludeOfLight,
+        ] {
+            verify_oot_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_oot_quest_items() {
+        for item in [
+            OotItem::KokiriEmerald,
+            OotItem::GoronRuby,
+            OotItem::ZoraSapphire,
+            OotItem::ForestMedallion,
+            OotItem::FireMedallion,
+            OotItem::WaterMedallion,
+            OotItem::ShadowMedallion,
+            OotItem::SpiritMedallion,
+            OotItem::LightMedallion,
+        ] {
+            verify_oot_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_oot_bottles() {
+        for item in [
+            OotItem::Bottle,
+            OotItem::BottleRedPotion,
+            OotItem::BottleFairy,
+            OotItem::BottleBlueFire,
+        ] {
+            verify_oot_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_mm_transformation_masks() {
+        for item in [
+            MmItem::DekuMask,
+            MmItem::GoronMask,
+            MmItem::ZoraMask,
+            MmItem::FierceDeityMask,
+        ] {
+            verify_mm_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_mm_regular_masks() {
+        for item in [
+            MmItem::PostmanHat,
+            MmItem::AllNightMask,
+            MmItem::BlastMask,
+            MmItem::StoneMask,
+            MmItem::BunnyHood,
+            MmItem::GiantMask,
+        ] {
+            verify_mm_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_mm_boss_remains() {
+        for item in [
+            MmItem::OdolwaRemains,
+            MmItem::GohtRemains,
+            MmItem::GyorgRemains,
+            MmItem::TwinmoldRemains,
+        ] {
+            verify_mm_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_mm_songs() {
+        for item in [
+            MmItem::SongOfTime,
+            MmItem::SongOfHealing,
+            MmItem::OathToOrder,
+            MmItem::ElegyOfEmptiness,
+        ] {
+            verify_mm_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_combined_items() {
+        // Test combined Item type preserves game information
+        let oot_items = [
+            Item::Oot(OotItem::Hookshot),
+            Item::Oot(OotItem::MasterSword),
+            Item::Oot(OotItem::ForestMedallion),
+        ];
+        let mm_items = [
+            Item::Mm(MmItem::DekuMask),
+            Item::Mm(MmItem::OdolwaRemains),
+            Item::Mm(MmItem::Hookshot),
+        ];
+
+        for item in oot_items {
+            verify_combined_item_semantic_roundtrip(item);
+        }
+        for item in mm_items {
+            verify_combined_item_semantic_roundtrip(item);
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_item_category_all() {
+        // Verify all item categories preserve semantic properties
+        let categories = [
+            ItemCategory::Sword,
+            ItemCategory::Shield,
+            ItemCategory::Tunic,
+            ItemCategory::Boots,
+            ItemCategory::Mask,
+            ItemCategory::TransformationMask,
+            ItemCategory::Equipment,
+            ItemCategory::Magic,
+            ItemCategory::Song,
+            ItemCategory::Ocarina,
+            ItemCategory::DungeonItem,
+            ItemCategory::SmallKey,
+            ItemCategory::BossKey,
+            ItemCategory::Upgrade,
+            ItemCategory::Consumable,
+            ItemCategory::QuestItem,
+            ItemCategory::Token,
+            ItemCategory::Bottle,
+            ItemCategory::Trade,
+            ItemCategory::Special,
+        ];
+
+        for category in categories {
+            let serialized = serde_yaml::to_string(&category).unwrap();
+            let deserialized: ItemCategory = serde_yaml::from_str(&serialized).unwrap();
+
+            // Verify hash consistency (semantic property)
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+
+            let mut h1 = DefaultHasher::new();
+            let mut h2 = DefaultHasher::new();
+            category.hash(&mut h1);
+            deserialized.hash(&mut h2);
+
+            assert_eq!(
+                h1.finish(),
+                h2.finish(),
+                "hash mismatch after roundtrip for {:?}",
+                category
+            );
+        }
+    }
+
+    #[test]
+    fn test_semantic_roundtrip_double() {
+        // Verify that multiple roundtrips preserve semantics
+        let item = OotItem::Hookshot;
+
+        let serialized1 = serde_yaml::to_string(&item).unwrap();
+        let deserialized1: OotItem = serde_yaml::from_str(&serialized1).unwrap();
+
+        let serialized2 = serde_yaml::to_string(&deserialized1).unwrap();
+        let deserialized2: OotItem = serde_yaml::from_str(&serialized2).unwrap();
+
+        // All versions should have identical semantic properties
+        assert_eq!(item.category(), deserialized1.category());
+        assert_eq!(item.category(), deserialized2.category());
+        assert_eq!(item.max_count(), deserialized1.max_count());
+        assert_eq!(item.max_count(), deserialized2.max_count());
+
+        // Serialization should be stable (identical strings)
+        assert_eq!(serialized1, serialized2);
+    }
 }

--- a/crate/ootmm/tests/semantic_equivalence_tests.rs
+++ b/crate/ootmm/tests/semantic_equivalence_tests.rs
@@ -1,0 +1,554 @@
+//! Semantic equivalence tests for roundtrip operations.
+//!
+//! These tests go beyond structural equality to verify that roundtripped
+//! data behaves identically to the original. This catches subtle bugs where
+//! serialization/deserialization preserves structure but loses semantic meaning.
+//!
+//! Key improvements over structural-only roundtrip tests:
+//! 1. Expression roundtrips are tested by evaluating against multiple contexts
+//! 2. Item roundtrips verify functional properties are preserved
+//! 3. Edge cases test normalization behavior (whitespace, parentheses, etc.)
+
+mod common;
+
+use common::MockEvalContext;
+use ootmm::expr::{eval, parse, Expr};
+
+// ============================================================================
+// Test Context Generation
+// ============================================================================
+
+/// Generates a variety of test contexts to verify semantic equivalence.
+/// Returns contexts that cover different combinations of game state.
+fn test_contexts() -> Vec<MockEvalContext> {
+    vec![
+        // Empty context (baseline)
+        MockEvalContext::new(),
+        // Adult with common items
+        MockEvalContext::adult()
+            .with_items(["HOOKSHOT", "BOW", "BOMB"])
+            .with_event("MIDO_MOVED"),
+        // Child with child items
+        MockEvalContext::child()
+            .with_items(["BOOMERANG", "SLINGSHOT", "DEKU_STICK"])
+            .with_event("MET_ZELDA"),
+        // Adult with settings and tricks
+        MockEvalContext::adult()
+            .with_items(["HOOKSHOT", "LONGSHOT"])
+            .with_setting("shuffle_scrubs")
+            .with_trick("logic_deku_b1_skip"),
+        // Context with many items
+        MockEvalContext::adult()
+            .with_items([
+                "HOOKSHOT",
+                "LONGSHOT",
+                "BOW",
+                "BOMB",
+                "BOOMERANG",
+                "SLINGSHOT",
+                "MASTER_SWORD",
+            ])
+            .with_event("FOREST_TEMPLE_CLEAR")
+            .with_event("WATER_TEMPLE_CLEAR")
+            .with_setting("skip_child_zelda"),
+        // Context with only events
+        MockEvalContext::new()
+            .with_event("MIDO_MOVED")
+            .with_event("DEKU_TREE_CLEAR"),
+        // Context with only settings
+        MockEvalContext::new()
+            .with_setting("shuffle_scrubs")
+            .with_setting("skip_child_zelda"),
+    ]
+}
+
+// ============================================================================
+// Semantic Equivalence Helpers
+// ============================================================================
+
+/// Tests that two expressions are semantically equivalent by evaluating them
+/// against all test contexts and verifying identical results.
+fn assert_semantically_equivalent(expr1: &Expr, expr2: &Expr, description: &str) {
+    for (i, ctx) in test_contexts().iter().enumerate() {
+        let result1 = eval(expr1, ctx);
+        let result2 = eval(expr2, ctx);
+
+        match (&result1, &result2) {
+            (Ok(v1), Ok(v2)) => {
+                assert_eq!(
+                    v1, v2,
+                    "{}: expressions differ in context #{}: {:?} vs {:?}",
+                    description, i, v1, v2
+                );
+            }
+            (Err(_), Err(_)) => {
+                // Both errored, consider equivalent for this context
+            }
+            _ => {
+                panic!(
+                    "{}: one expression errored in context #{}: {:?} vs {:?}",
+                    description, i, result1, result2
+                );
+            }
+        }
+    }
+}
+
+/// Tests roundtrip with semantic equivalence verification.
+/// Parses, displays, re-parses, then verifies both semantic and structural equivalence.
+fn test_semantic_roundtrip(expr_str: &str) {
+    let expr1 = parse(expr_str).unwrap_or_else(|e| {
+        panic!("First parse of '{}' should succeed: {:?}", expr_str, e);
+    });
+
+    let displayed = expr1.to_string();
+
+    let expr2 = parse(&displayed).unwrap_or_else(|e| {
+        panic!(
+            "Second parse of displayed '{}' (from '{}') should succeed: {:?}",
+            displayed, expr_str, e
+        );
+    });
+
+    // Structural equality check
+    assert_eq!(
+        expr1, expr2,
+        "Roundtrip should preserve structure for '{}' (displayed as '{}')",
+        expr_str, displayed
+    );
+
+    // Semantic equivalence check - verify both evaluate identically
+    assert_semantically_equivalent(
+        &expr1,
+        &expr2,
+        &format!("Roundtrip semantic check for '{}'", expr_str),
+    );
+}
+
+// ============================================================================
+// Expression Roundtrip with Semantic Verification
+// ============================================================================
+
+mod expression_roundtrip_semantic {
+    use super::*;
+
+    #[test]
+    fn test_boolean_literals_semantic() {
+        test_semantic_roundtrip("true");
+        test_semantic_roundtrip("false");
+    }
+
+    #[test]
+    fn test_identifiers_semantic() {
+        test_semantic_roundtrip("is_adult");
+        test_semantic_roundtrip("is_child");
+    }
+
+    #[test]
+    fn test_has_function_semantic() {
+        test_semantic_roundtrip("has(HOOKSHOT)");
+        test_semantic_roundtrip("has(BOW)");
+        test_semantic_roundtrip("has(BOMB)");
+        test_semantic_roundtrip("has(BOOMERANG)");
+    }
+
+    #[test]
+    fn test_event_function_semantic() {
+        test_semantic_roundtrip("event(MIDO_MOVED)");
+        test_semantic_roundtrip("event(FOREST_TEMPLE_CLEAR)");
+        test_semantic_roundtrip("event(DEKU_TREE_CLEAR)");
+    }
+
+    #[test]
+    fn test_setting_function_semantic() {
+        test_semantic_roundtrip("setting(shuffle_scrubs)");
+        test_semantic_roundtrip("setting(skip_child_zelda)");
+    }
+
+    #[test]
+    fn test_trick_function_semantic() {
+        test_semantic_roundtrip("trick(logic_deku_b1_skip)");
+    }
+
+    #[test]
+    fn test_and_expressions_semantic() {
+        test_semantic_roundtrip("true && true");
+        test_semantic_roundtrip("true && false");
+        test_semantic_roundtrip("is_adult && has(HOOKSHOT)");
+        test_semantic_roundtrip("has(HOOKSHOT) && has(BOW)");
+    }
+
+    #[test]
+    fn test_or_expressions_semantic() {
+        test_semantic_roundtrip("true || false");
+        test_semantic_roundtrip("has(HOOKSHOT) || has(LONGSHOT)");
+        test_semantic_roundtrip("is_adult || is_child");
+    }
+
+    #[test]
+    fn test_not_expressions_semantic() {
+        test_semantic_roundtrip("!true");
+        test_semantic_roundtrip("!false");
+        test_semantic_roundtrip("!is_adult");
+        test_semantic_roundtrip("!has(HOOKSHOT)");
+        test_semantic_roundtrip("!!true");
+    }
+
+    #[test]
+    fn test_complex_expressions_semantic() {
+        test_semantic_roundtrip("(has(HOOKSHOT) || has(LONGSHOT)) && is_adult");
+        test_semantic_roundtrip("is_adult && has(HOOKSHOT) && event(MIDO_MOVED)");
+        test_semantic_roundtrip("(is_adult && has(BOW)) || (is_child && has(SLINGSHOT))");
+        test_semantic_roundtrip("event(FOREST_TEMPLE_CLEAR) || setting(skip_child_zelda)");
+    }
+
+    #[test]
+    fn test_deeply_nested_semantic() {
+        test_semantic_roundtrip("((a && b) || c) && d");
+        test_semantic_roundtrip("(((true && false) || true) && false) || true");
+    }
+
+    #[test]
+    fn test_real_ootmm_logic_semantic() {
+        // Real expressions from OoTMM logic files
+        test_semantic_roundtrip("is_child && has(BOOMERANG)");
+        test_semantic_roundtrip("has(HOOKSHOT) || has(LONGSHOT)");
+        test_semantic_roundtrip("(has(BOW) && is_adult) || trick(logic_deku_b1_skip)");
+    }
+}
+
+// ============================================================================
+// Whitespace Normalization Semantic Tests
+// ============================================================================
+
+mod whitespace_normalization {
+    use super::*;
+
+    /// Tests that different whitespace variations parse to semantically equivalent expressions.
+    fn test_whitespace_equivalence(expressions: &[&str]) {
+        let parsed: Vec<_> = expressions
+            .iter()
+            .map(|s| parse(s).expect(&format!("'{}' should parse", s)))
+            .collect();
+
+        // All should be structurally equal
+        for (i, expr) in parsed.iter().enumerate().skip(1) {
+            assert_eq!(
+                &parsed[0], expr,
+                "Whitespace variant {} '{}' should equal '{}' structurally",
+                i, expressions[i], expressions[0]
+            );
+        }
+
+        // All should be semantically equivalent
+        for (i, expr) in parsed.iter().enumerate().skip(1) {
+            assert_semantically_equivalent(
+                &parsed[0],
+                expr,
+                &format!(
+                    "Whitespace variant '{}' vs '{}'",
+                    expressions[0], expressions[i]
+                ),
+            );
+        }
+    }
+
+    #[test]
+    fn test_and_whitespace_variations() {
+        test_whitespace_equivalence(&["a && b", "a&&b", "a  &&  b", " a && b ", "a && b"]);
+    }
+
+    #[test]
+    fn test_or_whitespace_variations() {
+        test_whitespace_equivalence(&["a || b", "a||b", "a  ||  b", " a || b "]);
+    }
+
+    #[test]
+    fn test_function_call_whitespace() {
+        test_whitespace_equivalence(&["has(HOOKSHOT)", "has( HOOKSHOT )", "has(  HOOKSHOT  )"]);
+    }
+
+    #[test]
+    fn test_complex_whitespace_variations() {
+        test_whitespace_equivalence(&[
+            "has(HOOKSHOT) && is_adult",
+            "has(HOOKSHOT)&&is_adult",
+            "has( HOOKSHOT ) && is_adult",
+            "  has(HOOKSHOT)  &&  is_adult  ",
+        ]);
+    }
+}
+
+// ============================================================================
+// Parentheses Normalization Tests
+// ============================================================================
+
+mod parentheses_normalization {
+    use super::*;
+
+    /// Tests that expressions with different (but logically valid) parenthesization
+    /// are semantically equivalent.
+    #[test]
+    fn test_extra_parentheses_semantic() {
+        let base = parse("a && b").unwrap();
+        let extra = parse("(a && b)").unwrap();
+        let double = parse("((a && b))").unwrap();
+
+        assert_semantically_equivalent(&base, &extra, "extra parens around and");
+        assert_semantically_equivalent(&base, &double, "double extra parens around and");
+    }
+
+    #[test]
+    fn test_nested_parentheses_roundtrip() {
+        // Display adds parentheses, but semantic meaning should be preserved
+        let original = "a && b || c";
+        let expr1 = parse(original).unwrap();
+        let displayed = expr1.to_string();
+        let expr2 = parse(&displayed).unwrap();
+
+        assert_semantically_equivalent(
+            &expr1,
+            &expr2,
+            "parentheses normalization preserves semantics",
+        );
+    }
+
+    #[test]
+    fn test_redundant_parentheses_semantic() {
+        let expr1 = parse("(true)").unwrap();
+        let expr2 = parse("true").unwrap();
+        assert_semantically_equivalent(&expr1, &expr2, "redundant parens on literal");
+    }
+}
+
+// ============================================================================
+// Edge Cases and Boundary Conditions
+// ============================================================================
+
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn test_single_variable_semantic() {
+        // Single variables should roundtrip and maintain evaluation behavior
+        for var in ["x", "foo", "is_adult", "is_child", "unknown_var"] {
+            test_semantic_roundtrip(var);
+        }
+    }
+
+    #[test]
+    fn test_number_literals_semantic() {
+        test_semantic_roundtrip("42");
+        test_semantic_roundtrip("0");
+        test_semantic_roundtrip("999999");
+    }
+
+    #[test]
+    fn test_deeply_nested_and_chain_semantic() {
+        test_semantic_roundtrip("a && b && c && d && e");
+    }
+
+    #[test]
+    fn test_deeply_nested_or_chain_semantic() {
+        test_semantic_roundtrip("a || b || c || d || e");
+    }
+
+    #[test]
+    fn test_mixed_operators_semantic() {
+        test_semantic_roundtrip("a && b || c && d");
+        test_semantic_roundtrip("(a || b) && (c || d)");
+        test_semantic_roundtrip("!a && !b || c");
+    }
+
+    #[test]
+    fn test_negation_of_complex_expressions_semantic() {
+        test_semantic_roundtrip("!(a && b)");
+        test_semantic_roundtrip("!(a || b)");
+        test_semantic_roundtrip("!(!a)");
+        test_semantic_roundtrip("!(has(HOOKSHOT) && is_adult)");
+    }
+
+    #[test]
+    fn test_function_with_multiple_args_semantic() {
+        test_semantic_roundtrip("has(BOTTLE, 2)");
+        test_semantic_roundtrip("has(Small_Key_Forest_Temple, 5)");
+    }
+
+    #[test]
+    fn test_cond_function_semantic() {
+        test_semantic_roundtrip("cond(true, true, false)");
+        test_semantic_roundtrip("cond(is_adult, has(HOOKSHOT), has(BOOMERANG))");
+    }
+}
+
+// ============================================================================
+// Evaluation Context Sensitivity Tests
+// ============================================================================
+
+mod context_sensitivity {
+    use super::*;
+
+    /// Tests that an expression evaluates differently in different contexts
+    /// (proving our semantic tests are meaningful).
+    #[test]
+    fn test_context_actually_matters() {
+        let expr = parse("is_adult && has(HOOKSHOT)").unwrap();
+
+        // Context 1: adult with hookshot - should be true
+        let ctx1 = MockEvalContext::adult().with_item("HOOKSHOT");
+        assert!(eval(&expr, &ctx1).unwrap());
+
+        // Context 2: child with hookshot - should be false
+        let ctx2 = MockEvalContext::child().with_item("HOOKSHOT");
+        assert!(!eval(&expr, &ctx2).unwrap());
+
+        // Context 3: adult without hookshot - should be false
+        let ctx3 = MockEvalContext::adult();
+        assert!(!eval(&expr, &ctx3).unwrap());
+    }
+
+    #[test]
+    fn test_events_are_context_sensitive() {
+        let expr = parse("event(MIDO_MOVED)").unwrap();
+
+        let with_event = MockEvalContext::new().with_event("MIDO_MOVED");
+        let without_event = MockEvalContext::new();
+
+        assert!(eval(&expr, &with_event).unwrap());
+        assert!(!eval(&expr, &without_event).unwrap());
+    }
+
+    #[test]
+    fn test_settings_are_context_sensitive() {
+        let expr = parse("setting(skip_child_zelda)").unwrap();
+
+        let with_setting = MockEvalContext::new().with_setting("skip_child_zelda");
+        let without_setting = MockEvalContext::new();
+
+        assert!(eval(&expr, &with_setting).unwrap());
+        assert!(!eval(&expr, &without_setting).unwrap());
+    }
+}
+
+// ============================================================================
+// Double Roundtrip Tests
+// ============================================================================
+
+mod double_roundtrip {
+    use super::*;
+
+    /// Tests that multiple roundtrips preserve semantic equivalence.
+    fn test_double_semantic_roundtrip(expr_str: &str) {
+        let original = parse(expr_str).unwrap();
+
+        // First roundtrip
+        let displayed1 = original.to_string();
+        let roundtrip1 = parse(&displayed1).unwrap();
+
+        // Second roundtrip
+        let displayed2 = roundtrip1.to_string();
+        let roundtrip2 = parse(&displayed2).unwrap();
+
+        // All three should be semantically equivalent
+        assert_semantically_equivalent(&original, &roundtrip1, "first roundtrip");
+        assert_semantically_equivalent(&original, &roundtrip2, "second roundtrip");
+        assert_semantically_equivalent(&roundtrip1, &roundtrip2, "between roundtrips");
+
+        // After first roundtrip, structural equality should be stable
+        assert_eq!(
+            roundtrip1, roundtrip2,
+            "multiple roundtrips should stabilize structure"
+        );
+    }
+
+    #[test]
+    fn test_double_roundtrip_simple() {
+        test_double_semantic_roundtrip("true");
+        test_double_semantic_roundtrip("a && b");
+        test_double_semantic_roundtrip("a || b");
+    }
+
+    #[test]
+    fn test_double_roundtrip_complex() {
+        test_double_semantic_roundtrip("(has(HOOKSHOT) || has(LONGSHOT)) && is_adult");
+        test_double_semantic_roundtrip("event(MIDO_MOVED) || setting(skip_child_zelda)");
+    }
+
+    #[test]
+    fn test_double_roundtrip_with_normalization() {
+        // Expression that gets normalized on first roundtrip
+        test_double_semantic_roundtrip("a && b || c");
+    }
+}
+
+// ============================================================================
+// Specific Bug Prevention Tests
+// ============================================================================
+
+mod bug_prevention {
+    use super::*;
+
+    /// Ensures that operator precedence is correctly preserved through roundtrip.
+    #[test]
+    fn test_precedence_preserved_semantically() {
+        // && has higher precedence than ||
+        // "a && b || c" means "(a && b) || c", not "a && (b || c)"
+        let expr = parse("a && b || c").unwrap();
+
+        // Test with context where the difference matters
+        // If a=false, b=true, c=true:
+        //   (a && b) || c = (false && true) || true = false || true = true
+        //   a && (b || c) = false && (true || true) = false && true = false
+        let ctx = MockEvalContext::new()
+            .with_event("b")
+            .with_event("c")
+            // 'a' is not set, so it evaluates to false
+
+        ;
+        // After roundtrip, should behave the same
+        let displayed = expr.to_string();
+        let roundtrip = parse(&displayed).unwrap();
+
+        let original_result = eval(&expr, &ctx);
+        let roundtrip_result = eval(&roundtrip, &ctx);
+
+        assert_eq!(
+            original_result.ok(),
+            roundtrip_result.ok(),
+            "Operator precedence must be preserved through roundtrip"
+        );
+    }
+
+    /// Ensures that short-circuit evaluation is preserved.
+    #[test]
+    fn test_short_circuit_preserved() {
+        // In "false && x", x should not be evaluated (short-circuit)
+        // This is semantic behavior that must be preserved
+        let expr1 = parse("false && unknown_func()").unwrap();
+        let displayed = expr1.to_string();
+        let expr2 = parse(&displayed).unwrap();
+
+        let ctx = MockEvalContext::new();
+
+        // Both should succeed without error (due to short-circuit)
+        // unknown_func would cause an error if evaluated
+        let result1 = eval(&expr1, &ctx).ok();
+        let result2 = eval(&expr2, &ctx).ok();
+
+        assert_eq!(result1, result2);
+        assert_eq!(result1, Some(false));
+    }
+
+    /// Ensures that double negation works correctly through roundtrip.
+    #[test]
+    fn test_double_negation_semantic() {
+        let expr = parse("!!true").unwrap();
+        let displayed = expr.to_string();
+        let roundtrip = parse(&displayed).unwrap();
+
+        let ctx = MockEvalContext::new();
+
+        assert_eq!(eval(&expr, &ctx).ok(), Some(true));
+        assert_eq!(eval(&roundtrip, &ctx).ok(), Some(true));
+    }
+}

--- a/crate/ootr/src/model.rs
+++ b/crate/ootr/src/model.rs
@@ -852,4 +852,262 @@ mod tests {
             );
         }
     }
+
+    // ===== SEMANTIC EQUIVALENCE ROUNDTRIP TESTS =====
+    //
+    // These tests verify that roundtripped model types preserve semantic properties,
+    // not just structural equality. The types should behave identically after
+    // Display -> FromStr conversion.
+
+    /// Verifies that a Medallion preserves its Item conversion after roundtrip.
+    fn verify_medallion_semantic_roundtrip(medallion: Medallion) {
+        let display_str = medallion.to_string();
+        let parsed = Medallion::from_str(&display_str).unwrap();
+
+        // Structural check
+        assert_eq!(medallion, parsed);
+
+        // Semantic checks - verify Item conversion is preserved
+        let original_item: Item = medallion.into();
+        let roundtrip_item: Item = parsed.into();
+        assert_eq!(
+            original_item.name(),
+            roundtrip_item.name(),
+            "Item name mismatch after roundtrip for {:?}",
+            medallion
+        );
+
+        // Verify conversion back to Medallion works
+        let back_from_original = Medallion::try_from(original_item.clone());
+        let back_from_roundtrip = Medallion::try_from(roundtrip_item.clone());
+        assert_eq!(
+            back_from_original, back_from_roundtrip,
+            "Medallion conversion mismatch for {:?}",
+            medallion
+        );
+    }
+
+    /// Verifies that a Stone preserves its Item conversion after roundtrip.
+    fn verify_stone_semantic_roundtrip(stone: Stone) {
+        let display_str = stone.to_string();
+        let parsed = Stone::from_str(&display_str).unwrap();
+
+        // Structural check
+        assert_eq!(stone, parsed);
+
+        // Semantic checks - verify Item conversion is preserved
+        let original_item: Item = stone.into();
+        let roundtrip_item: Item = parsed.into();
+        assert_eq!(
+            original_item.name(),
+            roundtrip_item.name(),
+            "Item name mismatch after roundtrip for {:?}",
+            stone
+        );
+
+        // Verify conversion back to Stone works
+        let back_from_original = Stone::try_from(original_item.clone());
+        let back_from_roundtrip = Stone::try_from(roundtrip_item.clone());
+        assert_eq!(
+            back_from_original, back_from_roundtrip,
+            "Stone conversion mismatch for {:?}",
+            stone
+        );
+    }
+
+    /// Verifies that a DungeonReward preserves its Item conversion after roundtrip.
+    fn verify_dungeon_reward_semantic_roundtrip(reward: DungeonReward) {
+        let display_str = reward.to_string();
+        let parsed = DungeonReward::from_str(&display_str).unwrap();
+
+        // Structural check
+        assert_eq!(reward, parsed);
+
+        // Semantic checks - verify Item conversion is preserved
+        let original_item: Item = reward.into();
+        let roundtrip_item: Item = parsed.into();
+        assert_eq!(
+            original_item.name(),
+            roundtrip_item.name(),
+            "Item name mismatch after roundtrip for {:?}",
+            reward
+        );
+
+        // Verify conversion back to DungeonReward works
+        let back_from_original = DungeonReward::try_from(original_item.clone());
+        let back_from_roundtrip = DungeonReward::try_from(roundtrip_item.clone());
+        assert_eq!(
+            back_from_original, back_from_roundtrip,
+            "DungeonReward conversion mismatch for {:?}",
+            reward
+        );
+    }
+
+    #[test]
+    fn test_medallion_semantic_roundtrip_all() {
+        for medallion in enum_iterator::all::<Medallion>() {
+            verify_medallion_semantic_roundtrip(medallion);
+        }
+    }
+
+    #[test]
+    fn test_stone_semantic_roundtrip_all() {
+        for stone in enum_iterator::all::<Stone>() {
+            verify_stone_semantic_roundtrip(stone);
+        }
+    }
+
+    #[test]
+    fn test_dungeon_reward_semantic_roundtrip_all() {
+        for reward in enum_iterator::all::<DungeonReward>() {
+            verify_dungeon_reward_semantic_roundtrip(reward);
+        }
+    }
+
+    #[test]
+    fn test_main_dungeon_reward_location_semantic_roundtrip() {
+        // MainDungeon -> DungeonRewardLocation -> string -> back
+        for dungeon in enum_iterator::all::<MainDungeon>() {
+            let location = DungeonRewardLocation::Dungeon(dungeon);
+            let location_str = location.as_str();
+            let parsed = DungeonRewardLocation::from_str(location_str).unwrap();
+
+            assert_eq!(location, parsed);
+
+            // Verify the dungeon can still be extracted correctly
+            match parsed {
+                DungeonRewardLocation::Dungeon(d) => assert_eq!(dungeon, d),
+                DungeonRewardLocation::LinksPocket => {
+                    panic!("Expected Dungeon, got LinksPocket")
+                }
+            }
+        }
+    }
+
+    // ===== EDGE CASES AND NORMALIZATION TESTS =====
+
+    #[test]
+    fn test_dungeon_reward_location_links_pocket_semantic() {
+        let location = DungeonRewardLocation::LinksPocket;
+        let location_str = location.as_str();
+        let parsed = DungeonRewardLocation::from_str(location_str).unwrap();
+
+        assert_eq!(location, parsed);
+
+        // Verify it's recognized as LinksPocket, not a dungeon
+        assert!(matches!(parsed, DungeonRewardLocation::LinksPocket));
+    }
+
+    #[test]
+    fn test_main_dungeon_display_string_stability() {
+        // Verify that display strings are stable across multiple roundtrips
+        for dungeon in enum_iterator::all::<MainDungeon>() {
+            let str1 = dungeon.to_string();
+            let parsed1 = MainDungeon::from_str(&str1).unwrap();
+            let str2 = parsed1.to_string();
+            let parsed2 = MainDungeon::from_str(&str2).unwrap();
+            let str3 = parsed2.to_string();
+
+            // All strings should be identical
+            assert_eq!(
+                str1, str2,
+                "First roundtrip changed display for {:?}",
+                dungeon
+            );
+            assert_eq!(
+                str2, str3,
+                "Second roundtrip changed display for {:?}",
+                dungeon
+            );
+        }
+    }
+
+    #[test]
+    fn test_dungeon_reward_double_roundtrip() {
+        // Verify semantic equivalence after multiple roundtrips
+        for reward in enum_iterator::all::<DungeonReward>() {
+            let str1 = reward.to_string();
+            let rt1 = DungeonReward::from_str(&str1).unwrap();
+            let str2 = rt1.to_string();
+            let rt2 = DungeonReward::from_str(&str2).unwrap();
+
+            // Item conversions should be identical at all stages
+            let item_original: Item = reward.into();
+            let item_rt1: Item = rt1.into();
+            let item_rt2: Item = rt2.into();
+
+            assert_eq!(item_original.name(), item_rt1.name());
+            assert_eq!(item_original.name(), item_rt2.name());
+        }
+    }
+
+    #[test]
+    fn test_medallion_distinguishable_after_roundtrip() {
+        // Ensure all medallions remain distinguishable after roundtrip
+        let roundtripped: Vec<_> = enum_iterator::all::<Medallion>()
+            .map(|m| {
+                let s = m.to_string();
+                Medallion::from_str(&s).unwrap()
+            })
+            .collect();
+
+        // All should be unique
+        for (i, m1) in roundtripped.iter().enumerate() {
+            for (j, m2) in roundtripped.iter().enumerate() {
+                if i != j {
+                    assert_ne!(m1, m2, "Medallions at {} and {} should be different", i, j);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_stone_distinguishable_after_roundtrip() {
+        // Ensure all stones remain distinguishable after roundtrip
+        let roundtripped: Vec<_> = enum_iterator::all::<Stone>()
+            .map(|s| {
+                let str = s.to_string();
+                Stone::from_str(&str).unwrap()
+            })
+            .collect();
+
+        // All should be unique
+        for (i, s1) in roundtripped.iter().enumerate() {
+            for (j, s2) in roundtripped.iter().enumerate() {
+                if i != j {
+                    assert_ne!(s1, s2, "Stones at {} and {} should be different", i, j);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_dungeon_reward_type_preservation() {
+        // Verify that Medallion/Stone type is preserved through DungeonReward roundtrip
+        for medallion in enum_iterator::all::<Medallion>() {
+            let reward = DungeonReward::Medallion(medallion);
+            let str = reward.to_string();
+            let parsed = DungeonReward::from_str(&str).unwrap();
+
+            match parsed {
+                DungeonReward::Medallion(m) => assert_eq!(medallion, m),
+                DungeonReward::Stone(_) => {
+                    panic!("Expected Medallion, got Stone after roundtrip")
+                }
+            }
+        }
+
+        for stone in enum_iterator::all::<Stone>() {
+            let reward = DungeonReward::Stone(stone);
+            let str = reward.to_string();
+            let parsed = DungeonReward::from_str(&str).unwrap();
+
+            match parsed {
+                DungeonReward::Stone(s) => assert_eq!(stone, s),
+                DungeonReward::Medallion(_) => {
+                    panic!("Expected Stone, got Medallion after roundtrip")
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Added new test file: semantic_equivalence_tests.rs
- Tests verify parse→display→parse produces semantically equivalent expressions
- Tests cover whitespace normalization, parentheses, edge cases
- Enhanced item.rs and model.rs with semantic roundtrip helpers

## Test plan
- [x] All 766+ tests pass (678 in ootmm, 88 in ootr)
- [x] cargo fmt && cargo clippy clean

Closes #245

🤖 Generated with [Claude Code](https://claude.ai/code)