### PR TITLE
feat: Wire equipment UI cells part 1 (#193-199)

### DIFF
--- a/crate/oottracker/src/mm_save.rs
+++ b/crate/oottracker/src/mm_save.rs
@@ -1460,6 +1460,15 @@ impl MmSave {
     pub fn has_twinmold_remains(&self) -> bool {
         self.quest_items.contains(MmQuestItems::REMAINS_TWINMOLD)
     }
+
+    // ========================================================================
+    // Bomber's Notebook Accessor Methods
+    // ========================================================================
+
+    /// Check if player has the Bomber's Notebook
+    pub fn has_bombers_notebook(&self) -> bool {
+        self.quest_items.contains(MmQuestItems::NOTEBOOK)
+    }
 }
 
 // ============================================================================

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -2916,7 +2916,7 @@ cells! {
     // ============================================================================
     MmBomberNotebook: Simple {
         img: ImageInfo::mm("bomber_notebook"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_bombers_notebook())),
         toggle: Box::new(|_| ()),
     },
 
@@ -2925,32 +2925,32 @@ cells! {
     // ============================================================================
     MmOcarina: Simple {
         img: ImageInfo::mm("ocarina"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_ocarina())),
         toggle: Box::new(|_| ()),
     },
     MmHerosBow: Simple {
         img: ImageInfo::mm("heros_bow"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_heros_bow())),
         toggle: Box::new(|_| ()),
     },
     MmFireArrow: Simple {
         img: ImageInfo::mm("fire_arrow"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_fire_arrow())),
         toggle: Box::new(|_| ()),
     },
     MmIceArrow: Simple {
         img: ImageInfo::mm("ice_arrow"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_ice_arrow())),
         toggle: Box::new(|_| ()),
     },
     MmLightArrow: Simple {
         img: ImageInfo::mm("light_arrow"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_light_arrow())),
         toggle: Box::new(|_| ()),
     },
     MmHookshot: Simple {
         img: ImageInfo::mm("hookshot"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_hookshot())),
         toggle: Box::new(|_| ()),
     },
     MmBombs: Simple {


### PR DESCRIPTION
## Summary
Wires 7 equipment UI cells in ui.rs:
- MmBomberNotebook - has_bombers_notebook()
- MmOcarina - has_ocarina()
- MmHerosBow - has_heros_bow()
- MmFireArrow - has_fire_arrow()
- MmIceArrow - has_ice_arrow()
- MmLightArrow - has_light_arrow()
- MmHookshot - has_hookshot()

Closes #193, #194, #195, #196, #197, #198, #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)