### PR TITLE
feat: Wire equipment UI cells Part 2 to MM save data (#200-207)

### DIFF
--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -2955,37 +2955,37 @@ cells! {
     },
     MmBombs: Simple {
         img: ImageInfo::mm("bombs"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_bombs())),
         toggle: Box::new(|_| ()),
     },
     MmBombchu: Simple {
         img: ImageInfo::mm("bombchu"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_bombchu())),
         toggle: Box::new(|_| ()),
     },
     MmPowderKeg: Simple {
         img: ImageInfo::mm("powder_keg"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_powder_keg())),
         toggle: Box::new(|_| ()),
     },
     MmLensOfTruth: Simple {
         img: ImageInfo::mm("lens_of_truth"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_lens_of_truth())),
         toggle: Box::new(|_| ()),
     },
     MmPictographBox: Simple {
         img: ImageInfo::mm("pictograph_box"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_pictograph_box())),
         toggle: Box::new(|_| ()),
     },
     MmGreatFairySword: Simple {
         img: ImageInfo::mm("great_fairy_sword"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_great_fairy_sword())),
         toggle: Box::new(|_| ()),
     },
     MmMagicBean: Simple {
         img: ImageInfo::mm("magic_bean"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_magic_bean())),
         toggle: Box::new(|_| ()),
     },
 
@@ -3162,7 +3162,7 @@ cells! {
     },
     MmMagic: Simple {
         img: ImageInfo::mm("magic"),
-        active: Box::new(|_| false),
+        active: Box::new(|state| state.ram.mm_save.as_ref().is_some_and(|save| save.has_magic())),
         toggle: Box::new(|_| ()),
     },
     MmDoubleDefense: Simple {


### PR DESCRIPTION
## Summary
- Wire equipment UI cells EQ8-EQ15 to MmSave accessor methods
- Issues: #200-207 (Bombs, Bombchu, Powder Keg, Lens of Truth, Pictograph Box, Great Fairy Sword, Magic Bean, Magic)

## Test plan
- [ ] Verify cargo fmt and clippy pass
- [ ] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)