### PR TITLE
feat: Add MM layout selection to GUI (#228)

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -45,7 +45,7 @@ use {
         net::{self, Connection},
         proto::Packet,
         save::*,
-        ui::{self, *},
+        ui::{self, LayoutPreference, *},
         ModelState,
     },
     semver::Version,
@@ -193,6 +193,7 @@ enum Message<R: Rando> {
     ResetUpdateState,
     RightClick,
     SetAutoUpdateCheck(bool),
+    SetLayoutPreference(LayoutPreference),
     SetMedOrder(ElementOrder),
     SetPasscode(String),
     SetConnection(Arc<dyn Connection>),
@@ -219,6 +220,7 @@ impl<R: Rando> fmt::Display for Message<R> {
 #[derive(Debug, Default)]
 struct MenuState {
     dismiss_btn: button::State,
+    layout_preference: pick_list::State<LayoutPreference>,
     med_order: pick_list::State<ElementOrder>,
     warp_song_order: pick_list::State<ElementOrder>,
     connection_kind: pick_list::State<ConnectionKind>,
@@ -342,16 +344,44 @@ struct State<R: Rando + 'static> {
 
 impl<R: Rando + 'static> State<R> {
     fn layout(&self) -> TrackerLayout {
-        if self
-            .connection
+        // Determine base layout based on layout preference
+        let layout_pref = self
+            .config
             .as_ref()
-            .is_none_or(|connection| connection.can_change_state())
-        {
-            TrackerLayout::from(&self.config)
-        } else if let Some(ref config) = self.config {
-            TrackerLayout::new_auto(config)
-        } else {
-            TrackerLayout::default_auto()
+            .map(|cfg| cfg.layout_preference)
+            .unwrap_or_default();
+
+        match layout_pref {
+            LayoutPreference::Oot => {
+                // Original OoT layout logic
+                if self
+                    .connection
+                    .as_ref()
+                    .is_none_or(|connection| connection.can_change_state())
+                {
+                    TrackerLayout::from(&self.config)
+                } else if let Some(ref config) = self.config {
+                    TrackerLayout::new_auto(config)
+                } else {
+                    TrackerLayout::default_auto()
+                }
+            }
+            LayoutPreference::Mm => TrackerLayout::MmDefault,
+            LayoutPreference::Combo => {
+                // For combo mode, use OoT layout for now
+                // TODO: Implement true combo layout that shows both OoT and MM items
+                if self
+                    .connection
+                    .as_ref()
+                    .is_none_or(|connection| connection.can_change_state())
+                {
+                    TrackerLayout::from(&self.config)
+                } else if let Some(ref config) = self.config {
+                    TrackerLayout::new_auto(config)
+                } else {
+                    TrackerLayout::default_auto()
+                }
+            }
         }
     }
 
@@ -693,6 +723,13 @@ impl Application for State<ootr_static::Rando> {
                     connection_params.set_kind(kind);
                 }
             }
+            Message::SetLayoutPreference(layout_preference) => {
+                self.config
+                    .as_mut()
+                    .expect("config not yet loaded")
+                    .layout_preference = layout_preference;
+                return self.save_config();
+            }
             Message::SetMedOrder(med_order) => {
                 self.config
                     .as_mut()
@@ -802,6 +839,13 @@ impl Application for State<ootr_static::Rando> {
                         .width(Length::Fill)
                         .horizontal_alignment(alignment::Horizontal::Center),
                 )
+                .push(Text::new("Tracker layout:"))
+                .push(PickList::new(
+                    &mut menu_state.layout_preference,
+                    all().collect_vec(),
+                    self.config.as_ref().map(|cfg| cfg.layout_preference),
+                    Message::SetLayoutPreference,
+                ))
                 .push(Text::new("Medallion order:"))
                 .push(PickList::new(
                     &mut menu_state.med_order,

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -287,6 +287,8 @@ pub struct Config {
     #[derivative(Default(value = "ElementOrder::SpiritShadowLight"))]
     #[serde(default = "default_warp_song_order")]
     pub warp_song_order: ElementOrder,
+    #[serde(default)]
+    pub layout_preference: LayoutPreference,
     pub auto_update_check: Option<bool>,
     #[derivative(Default(value = "VERSION"))]
     pub version: u8,
@@ -367,6 +369,40 @@ impl fmt::Display for ElementOrder {
             ElementOrder::LightSpiritShadow => write!(f, "Light first, Spirit before Shadow"),
             ElementOrder::ShadowSpiritLight => write!(f, "Shadow before Spirit, Light last"),
             ElementOrder::SpiritShadowLight => write!(f, "Spirit before Shadow, Light last"),
+        }
+    }
+}
+
+/// Layout preference for the tracker GUI, allowing selection between OoT, MM, or Combo tracker views.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    enum_iterator::Sequence,
+    Deserialize,
+    Serialize,
+    Protocol,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum LayoutPreference {
+    /// Ocarina of Time tracker layout (default)
+    #[default]
+    Oot,
+    /// Majora's Mask tracker layout
+    Mm,
+    /// Combined OoT/MM tracker layout
+    Combo,
+}
+
+impl fmt::Display for LayoutPreference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LayoutPreference::Oot => write!(f, "Ocarina of Time"),
+            LayoutPreference::Mm => write!(f, "Majora's Mask"),
+            LayoutPreference::Combo => write!(f, "Combo (OoT + MM)"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added LayoutPreference enum with OoT, MM, and Combo variants
- Added layout_preference field to Config struct with serde support
- Added layout selection dropdown to preferences menu
- Updated State::layout() to return appropriate TrackerLayout based on preference
- Issue: #228

## Test plan
- [ ] Verify cargo fmt and clippy pass
- [ ] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)