### PR TITLE
feat: Add MM small key accessor methods for SK2-SK4

### DIFF
--- a/crate/oottracker/src/mm_save.rs
+++ b/crate/oottracker/src/mm_save.rs
@@ -481,6 +481,23 @@ pub struct MmSmallKeys {
     pub stone_tower: u8,
 }
 
+impl MmSmallKeys {
+    /// Get small key count for Snowhead Temple
+    pub fn snowhead(&self) -> u8 {
+        self.snowhead
+    }
+
+    /// Get small key count for Great Bay Temple
+    pub fn great_bay(&self) -> u8 {
+        self.great_bay
+    }
+
+    /// Get small key count for Stone Tower Temple
+    pub fn stone_tower(&self) -> u8 {
+        self.stone_tower
+    }
+}
+
 // ============================================================================
 // Stray Fairies
 // ============================================================================

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -3223,17 +3223,17 @@ cells! {
         max: 1,
     },
     MmSnowheadSmallKeys: TrackerCellKind::MmSmallKeys {
-        get: Box::new(|keys| keys.snowhead),
+        get: Box::new(|keys| keys.snowhead()),
         set: Box::new(|keys, value| keys.snowhead = value),
         max: 3,
     },
     MmGreatBaySmallKeys: TrackerCellKind::MmSmallKeys {
-        get: Box::new(|keys| keys.great_bay),
+        get: Box::new(|keys| keys.great_bay()),
         set: Box::new(|keys, value| keys.great_bay = value),
         max: 1,
     },
     MmStoneTowerSmallKeys: TrackerCellKind::MmSmallKeys {
-        get: Box::new(|keys| keys.stone_tower),
+        get: Box::new(|keys| keys.stone_tower()),
         set: Box::new(|keys, value| keys.stone_tower = value),
         max: 4,
     },


### PR DESCRIPTION
## Summary
- Add small key accessor methods for Snowhead, Great Bay, and Stone Tower temples
- Wire UI cells to use the new accessor methods

Closes #214, #215, #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)