### PR TITLE
chore: Bump protocol VERSION to 6 and cleanup unused code

### DIFF
--- a/assets/oottracker-pj64-base.js
+++ b/assets/oottracker-pj64-base.js
@@ -1,7 +1,7 @@
 // The constants above are generated from Rust code in crate/oottracker-utils/src/release.rs. If they're missing, you have the wrong file.
 // Generated constants include: TCP_PORT, SAVE_ADDR, SAVE_SIZE, RAM_RANGES, MM_SAVE_ADDR, MM_SAVE_SIZE, MM_RAM_RANGES, OOT_COMBO_CONTEXT_ADDR, MM_COMBO_CONTEXT_ADDR
 
-const VERSION = 5; // do not rename this variable, the build script checks against it
+const VERSION = 6; // do not rename this variable, the build script checks against it
 
 // Game type detection
 var GAME_TYPE_UNKNOWN = 0;
@@ -439,7 +439,6 @@ sock.connect({host: "127.0.0.1", port: TCP_PORT}, function() {
                 // Send OoT RAM data
                 sendOotRamData(sock, rawRam);
 
-<<<<<<< HEAD
                 // For combo mode, also read and send MM data
                 if (detectedGame === GAME_TYPE_COMBO) {
                     var mmResult = readMmRamRanges(rawMmRam);
@@ -449,21 +448,6 @@ sock.connect({host: "127.0.0.1", port: TCP_PORT}, function() {
                     if (rawMmRam !== null) {
                         sendMmRamData(sock, rawMmRam);
                     }
-=======
-                // For combo mode, also read MM data (for persistent items/state)
-                if (detectedGame === GAME_TYPE_COMBO && typeof MM_RAM_RANGES !== 'undefined') {
-                    if (rawMmRam === null) {
-                        rawMmRam = [];
-                        for (var i = 0; i < MM_RAM_RANGES.length; i++) {
-                            rawMmRam.push(mem.getblock(ADDR_ANY_RDRAM.start + MM_RAM_RANGES[i][0], MM_RAM_RANGES[i][1]));
-                        }
-                    } else {
-                        for (var i = 0; i < MM_RAM_RANGES.length; i++) {
-                            rawMmRam[i] = mem.getblock(ADDR_ANY_RDRAM.start + MM_RAM_RANGES[i][0], MM_RAM_RANGES[i][1]);
-                        }
-                    }
-                    // TODO: Send MM data when protocol supports combo mode
->>>>>>> 6b6a82b (feat: Implement OoTMM combo detection for Project64)
                 }
             }
         });

--- a/crate/oottracker/src/net.rs
+++ b/crate/oottracker/src/net.rs
@@ -314,8 +314,6 @@ const TRANSITION_STABILITY_FRAMES: u32 = 3;
 struct ComboTransitionTracker {
     /// The last known MM save data (preserved when switching to OoT)
     last_mm_save: Option<MmSave>,
-    /// The last known OoT RAM data (preserved when switching to MM)
-    last_oot_ram: Option<Ram>,
     /// Number of consecutive frames the current game has been active
     frames_stable: u32,
     /// Whether we're currently in a transition period
@@ -353,11 +351,6 @@ impl ComboTransitionTracker {
             (ActiveGame::MajorasMask, ActiveGame::OcarinaOfTime) => TransitionState::MmToOot,
             _ => TransitionState::Stable,
         });
-    }
-
-    /// Preserve OoT RAM data for later restoration
-    fn preserve_oot_state(&mut self, ram: &Ram) {
-        self.last_oot_ram = Some(ram.clone());
     }
 
     /// Preserve MM save data for later restoration
@@ -645,9 +638,6 @@ async fn retroarch_read_ram_with_combo_transitions(
                     .await?;
 
             let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
-
-            // Preserve the current OoT state for when we switch back
-            combo_tracker.preserve_oot_state(&ram);
 
             // Preserve the new MM state
             combo_tracker.preserve_mm_state(&mm_save);

--- a/crate/oottracker/src/proto.rs
+++ b/crate/oottracker/src/proto.rs
@@ -12,7 +12,7 @@ use {
 };
 
 pub const TCP_PORT: u16 = 24801;
-pub const VERSION: u8 = 5;
+pub const VERSION: u8 = 6;
 
 #[derive(Debug, Clone, Protocol)]
 pub enum Packet {


### PR DESCRIPTION
## Summary
- Bump protocol VERSION from 5 to 6 in proto.rs for MmRamInit packet
- Update VERSION in oottracker-pj64-base.js to match
- Remove unused `last_oot_ram` field from ComboTransitionTracker struct
- Remove related `preserve_oot_state()` method
- Resolve merge conflict markers in pj64-base.js

Closes #290, #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)