### PR TITLE
fix(bizhawk): Fix memory leak in SetAutoTrackerContext FFI call

### DIFF
--- a/crate/oottracker-bizhawk/OotAutoTracker/src/MainForm.cs
+++ b/crate/oottracker-bizhawk/OotAutoTracker/src/MainForm.cs
@@ -476,8 +476,12 @@ namespace Net.Fenhl.OotAutoTracker {
 
         internal void SetAutoTrackerContext(IMemoryApi memoryApi, long addr, int length) {
             IntPtr data = Marshal.AllocHGlobal(length);
-            Marshal.Copy(memoryApi.ReadByteRange(addr, length, "System Bus").ToArray(), 0, data, length);
-            Native.model_set_tracker_ctx(this, length, data);
+            try {
+                Marshal.Copy(memoryApi.ReadByteRange(addr, length, "System Bus").ToArray(), 0, data, length);
+                Native.model_set_tracker_ctx(this, length, data);
+            } finally {
+                Marshal.FreeHGlobal(data);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes memory leak in the BizHawk FFI layer where `Marshal.AllocHGlobal` was never freed.

## Changes
- Added `finally` block with `Marshal.FreeHGlobal(data)` to ensure cleanup
- The Rust side uses `slice::from_raw_parts` to create a view over the data and copies it, so freeing is safe after the call

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)