### PR TITLE
fix(security): Convert state-changing endpoints from GET to POST

### DIFF
--- a/assets/web/static/proto.js
+++ b/assets/web/static/proto.js
@@ -209,10 +209,9 @@ function updateCell(cellID, data, offset) {
         default:
             throw 'unexpected CellOverlay variant';
     }
-    if (elt.hasAttribute('href')) {
-        elt.addEventListener('click', function(event) { event.preventDefault(); sendClick(cellID, false); return false; }, false);
+    if (elt.tagName === 'FORM') {
+        elt.addEventListener('submit', function(event) { event.preventDefault(); sendClick(cellID, false); return false; }, false);
         elt.addEventListener('contextmenu', function(event) { event.preventDefault(); sendClick(cellID, true); return false; }, false);
-        elt.removeAttribute('href');
     }
     return offset;
 }

--- a/crate/oottracker-web/src/http.rs
+++ b/crate/oottracker-web/src/http.rs
@@ -48,7 +48,9 @@ impl TrackerCellIdExt for TrackerCellId {
             format!("cols{colspan}")
         };
         html! {
-            a(id = format!("cell{cell_id}"), href = click_uri.to_string(), class = css_classes) : content; //TODO impl ToHtml for rocket::uri
+            form(id = format!("cell{cell_id}"), method = "POST", action = click_uri.to_string(), class = css_classes) {
+                button(type = "submit") : content;
+            }
         }
     }
 }
@@ -157,7 +159,7 @@ async fn mw_room_view(
     ))
 }
 
-#[rocket::get("/mw/<room>/<world>/<layout>/click/<cell_id>")]
+#[rocket::post("/mw/<room>/<world>/<layout>/click/<cell_id>")]
 async fn mw_click(
     mw_rooms: &State<MwRooms>,
     room: &str,
@@ -332,7 +334,7 @@ async fn restream_room_view(
     ))
 }
 
-#[rocket::get("/restream/<restreamer>/<runner>/<layout>/click/<cell_id>")]
+#[rocket::post("/restream/<restreamer>/<runner>/<layout>/click/<cell_id>")]
 async fn restream_click(
     restreams: &State<Restreams>,
     restreamer: &str,
@@ -416,7 +418,7 @@ async fn room(
     }).await?)
 }
 
-#[rocket::get("/room/<name>/click/<cell_id>")]
+#[rocket::post("/room/<name>/click/<cell_id>")]
 async fn click(
     pool: &State<PgPool>,
     rooms: &State<Rooms>,


### PR DESCRIPTION
## Summary
Converts state-changing endpoints from GET to POST to prevent CSRF attacks via image tags.

## Changes
- Changed `click` endpoint from `#[rocket::get(...)]` to `#[rocket::post(...)]`
- Changed `mw_click` endpoint from GET to POST
- Changed `restream_click` endpoint from GET to POST
- Updated `TrackerCellIdAction` to render `<button>` instead of `<a href>`
- Updated `updateCell` JavaScript to intercept form submissions instead of anchor clicks

## Security Benefit
This prevents CSRF attacks via image tags (`<img src="/room/foo/click/0">`) since browsers will not submit POST requests through image tags.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)