### PR TITLE
Implement boss/dungeon clear check tracking

### DIFF
--- a/crate/oottracker/src/checks.rs
+++ b/crate/oottracker/src/checks.rs
@@ -165,11 +165,18 @@ impl<R: Rando> CheckExt for Check<R> {
                         | crate::scene::ForestTempleSwitches::BETH_DEFEATED
                     )
                 ),
-                "Forest Temple Amy and Meg" => None, //TODO
+                "Forest Temple Amy and Meg" => Some(
+                    model.ram.scene_flags().forest_temple.switches.contains(
+                        crate::scene::ForestTempleSwitches::AMY_DEFEATED
+                        | crate::scene::ForestTempleSwitches::MEG_DEFEATED
+                    )
+                ),
 
                 // Water Temple
                 "Child Water Temple" => None, //TODO
-                "Water Temple Clear" => None, //TODO
+                "Water Temple Clear" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Morpha".into())).unwrap_or(false)
+                ),
 
                 _ => return Err(CheckError::UnknownEvent(event.clone())),
             },
@@ -367,19 +374,37 @@ impl<R: Rando> CheckExt for Check<R> {
                 "Ganons Castle MQ Forest Trial Freestanding Key" => None, //TODO
 
                 "Links Pocket" => Some(true), //TODO check if vanilla or rando, if vanilla check for appropriate flag
-                "Queen Gohma" => None, //TODO
-                "Twinrova" => None, //TODO
-                "Bongo Bongo" => None, //TODO
+                "Queen Gohma" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Event("Deku Tree Clear".into())).unwrap_or(false)
+                ),
+                "Twinrova" => None, // automatically checked via event_chk_inf
+                "Bongo Bongo" => None, // automatically checked via event_chk_inf
                 "Ganon" => Some(false), //TODO remember if game has been beaten (relevant for multiworld and go mode)
 
-                "Deku Tree Queen Gohma Heart" => None, //TODO
-                "Dodongos Cavern King Dodongo Heart" => None, //TODO
-                "Jabu Jabus Belly Barinade Heart" => None, //TODO
-                "Forest Temple Phantom Ganon Heart" => None, //TODO
-                "Fire Temple Volvagia Heart" => None, //TODO
-                "Water Temple Morpha Heart" => None, //TODO
-                "Spirit Temple Twinrova Heart" => None, //TODO
-                "Shadow Temple Bongo Bongo Heart" => None, //TODO
+                "Deku Tree Queen Gohma Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Event("Deku Tree Clear".into())).unwrap_or(false)
+                ),
+                "Dodongos Cavern King Dodongo Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("King Dodongo".into())).unwrap_or(false)
+                ),
+                "Jabu Jabus Belly Barinade Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Barinade".into())).unwrap_or(false)
+                ),
+                "Forest Temple Phantom Ganon Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Phantom Ganon".into())).unwrap_or(false)
+                ),
+                "Fire Temple Volvagia Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Volvagia".into())).unwrap_or(false)
+                ),
+                "Water Temple Morpha Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Morpha".into())).unwrap_or(false)
+                ),
+                "Spirit Temple Twinrova Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Twinrova".into())).unwrap_or(false)
+                ),
+                "Shadow Temple Bongo Bongo Heart" => Some(
+                    model.ram.save.event_chk_inf.checked(&Check::<R>::Location("Bongo Bongo".into())).unwrap_or(false)
+                ),
 
                 // Dungeon Skulls
                 "Deku Tree GS Basement Back Room" => None, //TODO

--- a/crate/oottracker/src/info_tables.rs
+++ b/crate/oottracker/src/info_tables.rs
@@ -49,6 +49,8 @@ flags_list! {
             event "Spirit Trial Clear" = 0x2000, //TODO only consider when known by settings knowledge or visual confirmation
             "Sheik at Colossus" = 0x1000,
             "Song from Ocarina of Time" = 0x0200,
+            "Twinrova" = 0x0002,
+            "Bongo Bongo" = 0x0001,
         },
         11: {
             event "Light Trial Clear" = 0x8000, //TODO only consider when known by settings knowledge or visual confirmation

--- a/crate/oottracker/src/scene.rs
+++ b/crate/oottracker/src/scene.rs
@@ -79,8 +79,10 @@ scene_flags! {
                 "Forest Temple First Stalfos Chest" = 0x0000_0001,
             },
             switches: {
+                MEG_DEFEATED /*vanilla*/ = 0x8000_0000,
                 BETH_DEFEATED /*vanilla*/ = 0x4000_0000,
                 JOELLE_DEFEATED /*vanilla*/ = 0x2000_0000,
+                AMY_DEFEATED /*vanilla*/ = 0x1000_0000,
             },
             room_clear: {
                 0 for "Forest Temple NW Outdoors" /*vanilla*/ -> "Forest Temple Outdoors High Balconies" = 0x0000_0400,


### PR DESCRIPTION
## Summary
- Implement check tracking for boss defeats and dungeon clears
- Add tracking for: Water Temple Clear, Forest Temple Amy/Meg, Spirit Temple boss, Shadow Temple boss
- Add Twinrova and Bongo Bongo flags to info_tables.rs
- Implement heart container check tracking

Closes #300

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes (for modified files)
- [x] Library compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)