### PR TITLE
Add settings-aware trial clear event tracking

### DIFF
--- a/crate/oottracker/src/checks.rs
+++ b/crate/oottracker/src/checks.rs
@@ -2,7 +2,7 @@ use {
     crate::{region::RegionLookupError, Check, ModelState},
     derivative::Derivative,
     derive_more::From,
-    ootr::{region::Mq, Rando},
+    ootr::{model::Medallion, region::Mq, Rando},
     std::{error::Error, fmt, io, sync::Arc},
 };
 
@@ -40,6 +40,95 @@ impl fmt::Display for CheckError {
 
 impl Error for CheckError {}
 
+/// Maps trial clear event names to their corresponding medallions.
+fn trial_clear_to_medallion(event: &str) -> Option<Medallion> {
+    match event {
+        "Spirit Trial Clear" => Some(Medallion::Spirit),
+        "Light Trial Clear" => Some(Medallion::Light),
+        "Fire Trial Clear" => Some(Medallion::Fire),
+        "Shadow Trial Clear" => Some(Medallion::Shadow),
+        "Water Trial Clear" => Some(Medallion::Water),
+        "Forest Trial Clear" => Some(Medallion::Forest),
+        _ => None,
+    }
+}
+
+/// Checks if a trial clear event is considered "cleared" based on settings knowledge.
+///
+/// Returns:
+/// - `Some(Some(true))` if the trial is known to be inactive (automatically cleared)
+/// - `Some(Some(false))` if the trial is known to be active and RAM shows not cleared
+/// - `Some(Some(true))` if the trial is known to be active and RAM shows cleared (visual confirmation)
+/// - `Some(None)` if the trial status is unknown and RAM shows not cleared
+/// - `None` if this is not a trial clear event
+fn check_trial_clear_with_settings(event: &str, model: &ModelState) -> Option<Option<bool>> {
+    let medallion = trial_clear_to_medallion(event)?;
+
+    // Check if we know whether this trial is active
+    match model.knowledge.active_trials.get(&medallion) {
+        Some(false) => {
+            // Trial is known to be inactive - consider it cleared
+            Some(Some(true))
+        }
+        Some(true) => {
+            // Trial is known to be active - trust RAM value (visual confirmation or actual state)
+            let ram_result = model
+                .ram
+                .save
+                .event_chk_inf
+                .checked(&Check::<ootr_static::Rando>::Event(event.to_string()));
+            Some(ram_result)
+        }
+        None => {
+            // Trial status unknown - check RAM, but be careful
+            let ram_result = model
+                .ram
+                .save
+                .event_chk_inf
+                .checked(&Check::<ootr_static::Rando>::Event(event.to_string()));
+            match ram_result {
+                Some(true) => {
+                    // RAM shows cleared - trust visual confirmation
+                    Some(Some(true))
+                }
+                Some(false) | None => {
+                    // RAM shows not cleared or unknown - we can't determine status
+                    // because we don't know if the trial is even active
+                    Some(None)
+                }
+            }
+        }
+    }
+}
+
+/// Checks if Kakariko Village Gate is open based on settings knowledge.
+///
+/// Returns:
+/// - `Some(Some(true))` if settings say kakariko is open
+/// - `Some(ram_value)` if settings say kakariko is closed (trust RAM/visual confirmation)
+/// - `None` if this is not the kakariko gate event
+fn check_kakariko_gate_with_settings(event: &str, model: &ModelState) -> Option<Option<bool>> {
+    if event != "Kakariko Village Gate Open" {
+        return None;
+    }
+
+    // Check the open_kakariko setting
+    if let Some(values) = model.knowledge.string_settings.get("open_kakariko") {
+        if values.contains("open") {
+            // Kakariko is set to open - gate is always open
+            return Some(Some(true));
+        }
+    }
+
+    // Either settings say closed, or we don't know - trust RAM value (visual confirmation)
+    let ram_result = model
+        .ram
+        .save
+        .inf_table
+        .checked(&Check::<ootr_static::Rando>::Event(event.to_string()));
+    Some(ram_result)
+}
+
 pub trait CheckExt {
     /// Check if this check has been completed.
     ///
@@ -52,6 +141,20 @@ pub trait CheckExt {
 impl<R: Rando> CheckExt for Check<R> {
     fn checked(&self, model: &ModelState) -> Result<Option<bool>, CheckError> {
         // event and location lists from Dev-R as of commit b670183e9aff520c20ac2ee65aa55e3740c5f4b4
+
+        // Settings-aware event checks: trial clears and kakariko gate
+        // These must be checked before standard RAM checks to apply settings knowledge
+        if let Check::Event(event) = self {
+            // Check trial clear events with settings awareness
+            if let Some(result) = check_trial_clear_with_settings(event, model) {
+                return Ok(result);
+            }
+            // Check kakariko gate with settings awareness
+            if let Some(result) = check_kakariko_gate_with_settings(event, model) {
+                return Ok(result);
+            }
+        }
+
         if let Some(checked) = model.ram.save.gold_skulltulas.checked(self) {
             return Ok(Some(checked));
         }

--- a/crate/oottracker/src/info_tables.rs
+++ b/crate/oottracker/src/info_tables.rs
@@ -46,16 +46,16 @@ flags_list! {
             SCARECROW_SONG = 0x1000,
         },
         10: {
-            event "Spirit Trial Clear" = 0x2000, //TODO only consider when known by settings knowledge or visual confirmation
+            event "Spirit Trial Clear" = 0x2000, // settings-aware: handled in checks.rs
             "Sheik at Colossus" = 0x1000,
             "Song from Ocarina of Time" = 0x0200,
         },
         11: {
-            event "Light Trial Clear" = 0x8000, //TODO only consider when known by settings knowledge or visual confirmation
-            event "Fire Trial Clear" = 0x4000, //TODO only consider when known by settings knowledge or visual confirmation
-            event "Shadow Trial Clear" = 0x2000, //TODO only consider when known by settings knowledge or visual confirmation
-            event "Water Trial Clear" = 0x1000, //TODO only consider when known by settings knowledge or visual confirmation
-            event "Forest Trial Clear" = 0x0800, //TODO only consider when known by settings knowledge or visual confirmation
+            event "Light Trial Clear" = 0x8000, // settings-aware: handled in checks.rs
+            event "Fire Trial Clear" = 0x4000, // settings-aware: handled in checks.rs
+            event "Shadow Trial Clear" = 0x2000, // settings-aware: handled in checks.rs
+            event "Water Trial Clear" = 0x1000, // settings-aware: handled in checks.rs
+            event "Forest Trial Clear" = 0x0800, // settings-aware: handled in checks.rs
         },
         12: {
             "ToT Light Arrows Cutscene" = 0x0010,
@@ -109,7 +109,7 @@ flags_list! {
 flags_list! {
     pub struct InfTable: [u8; 60] {
         15: {
-            event "Kakariko Village Gate Open" = 0x40, //TODO only consider when known by settings knowledge or visual confirmation
+            event "Kakariko Village Gate Open" = 0x40, // settings-aware: handled in checks.rs
         },
         32: {
             "GC Rolling Goron as Adult" = 0x02,


### PR DESCRIPTION
## Summary
- Add conditional logic for trial clear events (Spirit, Light, Fire, Shadow, Water, Forest)
- Add conditional logic for Kakariko Village Gate Open that respects open_kakariko setting
- Update info_tables.rs TODOs to reflect settings-aware implementation
- Modified CheckExt::checked() to intercept these events before standard RAM checks

## Changes Made
- `crate/oottracker/src/checks.rs`:
  - Added `trial_clear_to_medallion()` helper function
  - Added `check_trial_clear_with_settings()` function with settings-aware logic
  - Added `check_kakariko_gate_with_settings()` function
- `crate/oottracker/src/info_tables.rs`:
  - Updated TODO comments to reflect settings-aware implementation

Closes #301

## Test plan
- [ ] Verify trial clear events return `Some(true)` when trial is known inactive
- [ ] Verify trial clear events trust RAM when trial is known active
- [ ] Verify trial clear events return `None` when status unknown and RAM shows not cleared
- [ ] Verify Kakariko gate returns `Some(true)` when open_kakariko is "open"

🤖 Generated with [Claude Code](https://claude.com/claude-code)