### PR TITLE
docs: Improve BizHawk setup guide and add setup script

### DIFF
--- a/docs/BIZHAWK_SETUP.md
+++ b/docs/BIZHAWK_SETUP.md
@@ -4,7 +4,7 @@ This guide explains how to set up BizHawk with an OoT/MM randomizer ROM to use w
 
 ## Prerequisites
 
-1. **BizHawk Emulator** (v2.9+ recommended)
+1. **BizHawk Emulator** (v2.9+ required)
    - Download from: https://github.com/TASEmulators/BizHawk/releases
    - Extract to a folder (e.g., `C:\BizHawk` or `~/BizHawk`)
 
@@ -31,22 +31,62 @@ This guide explains how to set up BizHawk with an OoT/MM randomizer ROM to use w
 3. Configure settings
 4. Generate and download
 
-## Step 2: Install the OotAutoTracker BizHawk Plugin
+## Step 2: Build the OotAutoTracker BizHawk Plugin
 
-1. Build the tracker (or download a release):
+### Requirements
+- [Rust toolchain](https://rustup.rs/) (for building the native library)
+- [.NET SDK 6.0+](https://dotnet.microsoft.com/download) (for building the C# plugin)
+- BizHawk 2.9+ (for reference DLLs during compilation)
+
+### Quick Setup (Recommended)
+
+Use the setup script to configure your development environment:
+
+```bash
+# Run the setup script with your BizHawk installation path
+./scripts/setup-bizhawk-dev.sh /path/to/BizHawk
+
+# Example paths:
+./scripts/setup-bizhawk-dev.sh ~/Games/BizHawk-2.9.1
+./scripts/setup-bizhawk-dev.sh /opt/BizHawk
+./scripts/setup-bizhawk-dev.sh "C:\BizHawk"  # Windows (use quotes)
+```
+
+The script will:
+- Validate your BizHawk installation
+- Create a symlink for the build process
+- Check for required tools (.NET SDK, Rust)
+
+### Build the Plugin
+
+```bash
+# 1. Build the Rust FFI library (produces oottracker.dll)
+cargo build --release -p oottracker-csharp
+
+# 2. Build the BizHawk plugin (compiles C# wrapper)
+cargo build --release -p oottracker-bizhawk
+```
+
+After building, the plugin files are automatically placed in your BizHawk's ExternalTools folder (via the symlink).
+
+### Manual Setup (Alternative)
+
+If you prefer not to use the script:
+
+1. Create a symlink from your BizHawk installation:
    ```bash
-   cd oottracker
-   cargo build --release -p oottracker-bizhawk
+   ln -s /path/to/BizHawk crate/oottracker-bizhawk/OotAutoTracker/BizHawk
    ```
 
-2. Copy the plugin files to BizHawk:
-   - Copy `crate/oottracker-bizhawk/OotAutoTracker/` folder to:
-     - Windows: `<BizHawk>/ExternalTools/OotAutoTracker/`
-     - Linux: `~/.config/BizHawk/ExternalTools/OotAutoTracker/`
+2. Build as shown above.
 
-3. The folder should contain:
-   - `OotAutoTracker.dll`
-   - `oottracker.dll` (native library)
+### Output Files
+
+After a successful build:
+- `OotAutoTracker.dll` - The C# BizHawk plugin
+- `oottracker.dll` - The Rust native library
+
+Both are placed in `<BizHawk>/ExternalTools/` (via the symlink).
 
 ## Step 3: Run the Tracker GUI
 
@@ -68,7 +108,9 @@ This guide explains how to set up BizHawk with an OoT/MM randomizer ROM to use w
 2. **Open the External Tool**:
    - Tools → External Tools → OotAutoTracker
 
-3. **The tracker should auto-connect** to the GUI/web interface on port 24801
+3. **The plugin connects to the tracker** on port 24801
+   - The tracker GUI/web runs on port 24800
+   - The BizHawk plugin connects on port 24801
 
 4. **Verify connection**:
    - The tracker GUI should show items updating as you collect them in-game
@@ -77,13 +119,23 @@ This guide explains how to set up BizHawk with an OoT/MM randomizer ROM to use w
 ## Troubleshooting
 
 ### Plugin not appearing in BizHawk
-- Ensure the DLL files are in the correct ExternalTools folder
-- Check BizHawk's Tools → External Tools menu
+- Ensure both DLL files are in the ExternalTools folder
+- Check that you built with `--release` flag
 - Restart BizHawk after adding the plugin
+- Verify BizHawk version is 2.9+
+
+### Build fails: "BizHawk DLLs not found"
+- Run the setup script first: `./scripts/setup-bizhawk-dev.sh /path/to/BizHawk`
+- Or manually create the symlink as shown above
+- Ensure your BizHawk installation has the `dll/` subdirectory
+
+### Build fails: "dotnet not found"
+- Install .NET SDK 6.0 or later from https://dotnet.microsoft.com/download
+- Verify with: `dotnet --version`
 
 ### Tracker not connecting
 - Ensure the tracker GUI/web is running BEFORE opening the BizHawk plugin
-- Check that port 24801 is not blocked by firewall
+- Check that ports 24800 and 24801 are not blocked by firewall
 - Try restarting both the tracker and BizHawk
 
 ### Wrong game detected
@@ -93,7 +145,7 @@ This guide explains how to set up BizHawk with an OoT/MM randomizer ROM to use w
 
 ### Items not tracking
 - Verify the ROM is a randomizer ROM (not vanilla)
-- Check that you're using BizHawk's N64 core (not another emulator core)
+- Check that you're using BizHawk's N64 core (Mupen64Plus)
 - Try saving and reloading the game state
 
 ## Layout Options
@@ -105,12 +157,14 @@ The tracker supports multiple layouts:
 
 Select your layout in the tracker GUI settings.
 
-## Memory Addresses
+## Memory Addresses (Developer Reference)
 
 For developers/debugging, key memory ranges:
 - OoT Save: `0x11a5d0` (size: `0x1450`)
 - MM Save: `0x1ef670` (size: `0x48d0`)
 - Combo Context: `0x801c6fa0` (determines active game)
+
+**Note**: These addresses are for specific ROM versions and may vary.
 
 ## Links
 

--- a/scripts/setup-bizhawk-dev.sh
+++ b/scripts/setup-bizhawk-dev.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# BizHawk Development Environment Setup Script
+#
+# This script sets up the development environment for building the OotAutoTracker
+# BizHawk plugin. It links your BizHawk installation to the build location.
+#
+# Usage: ./scripts/setup-bizhawk-dev.sh /path/to/BizHawk
+#
+# Requirements:
+# - BizHawk 2.9+ installed
+# - .NET SDK 6.0+ (for building the C# plugin)
+# - Rust toolchain (for building oottracker.dll)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+BIZHAWK_TARGET="$PROJECT_ROOT/crate/oottracker-bizhawk/OotAutoTracker/BizHawk"
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Check arguments
+if [ -z "$1" ]; then
+    echo "Usage: $0 /path/to/BizHawk"
+    echo ""
+    echo "This script sets up the development environment for building the"
+    echo "OotAutoTracker BizHawk plugin."
+    echo ""
+    echo "Arguments:"
+    echo "  /path/to/BizHawk  Path to your BizHawk installation directory"
+    echo "                    (the folder containing EmuHawk.exe)"
+    echo ""
+    echo "Example:"
+    echo "  $0 /opt/BizHawk"
+    echo "  $0 ~/Games/BizHawk-2.9.1"
+    echo "  $0 'C:\\BizHawk'  # Windows path (use quotes)"
+    exit 1
+fi
+
+BIZHAWK_PATH="$1"
+
+# Validate BizHawk installation
+info "Validating BizHawk installation at: $BIZHAWK_PATH"
+
+if [ ! -d "$BIZHAWK_PATH" ]; then
+    error "Directory not found: $BIZHAWK_PATH"
+fi
+
+# Check for key BizHawk files
+if [ ! -f "$BIZHAWK_PATH/EmuHawk.exe" ] && [ ! -f "$BIZHAWK_PATH/EmuHawk" ]; then
+    error "EmuHawk executable not found. Is this a valid BizHawk installation?"
+fi
+
+if [ ! -d "$BIZHAWK_PATH/dll" ]; then
+    error "dll/ directory not found. Is this a valid BizHawk installation?"
+fi
+
+# Check for required DLLs
+REQUIRED_DLLS=(
+    "BizHawk.Client.Common.dll"
+    "BizHawk.Common.dll"
+    "BizHawk.Emulation.Common.dll"
+)
+
+for dll in "${REQUIRED_DLLS[@]}"; do
+    if [ ! -f "$BIZHAWK_PATH/dll/$dll" ]; then
+        error "Required DLL not found: dll/$dll"
+    fi
+done
+
+info "BizHawk installation validated successfully"
+
+# Create or update symlink
+if [ -L "$BIZHAWK_TARGET" ]; then
+    info "Removing existing symlink..."
+    rm "$BIZHAWK_TARGET"
+elif [ -d "$BIZHAWK_TARGET" ]; then
+    warn "Existing directory found at target location"
+    read -p "Remove existing directory and create symlink? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf "$BIZHAWK_TARGET"
+    else
+        error "Cannot proceed with existing directory"
+    fi
+fi
+
+info "Creating symlink: $BIZHAWK_TARGET -> $BIZHAWK_PATH"
+ln -s "$BIZHAWK_PATH" "$BIZHAWK_TARGET"
+
+# Verify symlink
+if [ ! -L "$BIZHAWK_TARGET" ]; then
+    error "Failed to create symlink"
+fi
+
+info "Symlink created successfully"
+
+# Check for .NET SDK
+if command -v dotnet &> /dev/null; then
+    DOTNET_VERSION=$(dotnet --version)
+    info ".NET SDK found: $DOTNET_VERSION"
+else
+    warn ".NET SDK not found. You'll need it to build the C# plugin."
+    warn "Install from: https://dotnet.microsoft.com/download"
+fi
+
+# Check for Rust
+if command -v cargo &> /dev/null; then
+    RUST_VERSION=$(cargo --version)
+    info "Rust found: $RUST_VERSION"
+else
+    warn "Rust not found. You'll need it to build oottracker.dll"
+    warn "Install from: https://rustup.rs"
+fi
+
+echo ""
+info "Setup complete! You can now build the BizHawk plugin:"
+echo ""
+echo "  # Build the Rust FFI library"
+echo "  cargo build --release -p oottracker-csharp"
+echo ""
+echo "  # Build the BizHawk plugin (includes C# build)"
+echo "  cargo build --release -p oottracker-bizhawk"
+echo ""
+echo "  # Output files will be in:"
+echo "  #   $BIZHAWK_TARGET/ExternalTools/OotAutoTracker.dll"
+echo "  #   $BIZHAWK_TARGET/ExternalTools/oottracker.dll"
+echo ""


### PR DESCRIPTION
## Summary

Improves the BizHawk setup documentation and adds an automated setup script.

### Changes

**New: `scripts/setup-bizhawk-dev.sh`**
- Validates BizHawk installation (checks for required DLLs)
- Creates symlink for build process
- Checks for required tools (.NET SDK, Rust)
- Provides clear usage instructions

**Updated: `docs/BIZHAWK_SETUP.md`**
- Corrected build order: `oottracker-csharp` then `oottracker-bizhawk`
- Explained the symlink requirement (BizHawk DLLs needed for C# compilation)
- Added troubleshooting for common build issues
- Clarified port usage (24800 for GUI/web, 24801 for BizHawk plugin)
- Added .NET SDK 6.0+ requirement
- Added manual setup alternative

### Testing

```bash
# Test the setup script
./scripts/setup-bizhawk-dev.sh /path/to/BizHawk

# Then build
cargo build --release -p oottracker-csharp
cargo build --release -p oottracker-bizhawk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)