### PR TITLE
fix(bizhawk): Update to BizHawk 2.11 API compatibility

### DIFF
--- a/crate/oottracker-bizhawk/OotAutoTracker/src/MainForm.cs
+++ b/crate/oottracker-bizhawk/OotAutoTracker/src/MainForm.cs
@@ -968,15 +968,15 @@ namespace Net.Fenhl.OotAutoTracker {
             if (this.prevSave != null) { this.prevSave.Dispose(); }
             this.prevSave = null;
             UpdateSave(false, "Save: waiting for game");
-            if ((APIs.GameInfo.GetGameInfo()?.Name ?? "Null") == "Null") {
+            if ((APIs.Emulation.GetGameInfo()?.Name ?? "Null") == "Null") {
                 this.model = ModelState.FromSaveAndKnowledge(Native.save_default(), Native.knowledge_none());
                 UpdateGame(false, "Not playing anything");
             } else {
                 var rom_ident = APIs.Memory.ReadByteRange(0x20, 0x18, "ROM");
                 // Check for OoT ROM: "THE LEGEND OF ZELDA \0"
-                bool isOotRom = Enumerable.SequenceEqual(rom_ident.GetRange(0, 0x15), new List<byte>(Encoding.UTF8.GetBytes("THE LEGEND OF ZELDA \0")));
+                bool isOotRom = Enumerable.SequenceEqual(rom_ident.Skip(0).Take(0x15).ToList(), new List<byte>(Encoding.UTF8.GetBytes("THE LEGEND OF ZELDA \0")));
                 // Check for MM ROM: "ZELDA MAJORA'S MASK " at offset 0x20
-                bool isMmRom = Enumerable.SequenceEqual(rom_ident.GetRange(0, 0x14), new List<byte>(Encoding.UTF8.GetBytes("ZELDA MAJORA'S MASK ")));
+                bool isMmRom = Enumerable.SequenceEqual(rom_ident.Skip(0).Take(0x14).ToList(), new List<byte>(Encoding.UTF8.GetBytes("ZELDA MAJORA'S MASK ")));
 
                 // Priority 1: Check for OoTMM combo ROM via ROM header signature
                 bool isComboFromHeader = DetectComboRomFromHeader();
@@ -1000,12 +1000,12 @@ namespace Net.Fenhl.OotAutoTracker {
                         UpdateGame(true, GetComboModeStatusString());
                     } else {
                         this.model = ModelState.FromSaveAndKnowledge(Native.save_default(), Native.knowledge_none());
-                        UpdateGame(false, $"Game: Expected OoT/OoTR/MM/MMR/OoTMM, found {APIs.GameInfo.GetGameInfo()?.Name ?? "Null"} ({string.Join<byte>(", ", rom_ident.GetRange(0, 0x15))})");
+                        UpdateGame(false, $"Game: Expected OoT/OoTR/MM/MMR/OoTMM, found {APIs.Emulation.GetGameInfo()?.Name ?? "Null"} ({string.Join<byte>(", ", rom_ident.Skip(0).Take(0x15).ToList())})");
                     }
                 } else if (isMmRom) {
                     // Majora's Mask detected
                     this.detectedGame = GameType.MajorasMask;
-                    var version = rom_ident.GetRange(0x14, 4);
+                    var version = rom_ident.Skip(0x14).Take(4).ToList();
                     this.isVanilla = Enumerable.SequenceEqual(version, new List<byte>(new byte[] { 0, 0, 0, 0 }));
                     this.model = ModelState.FromSaveAndKnowledge(Native.save_default(), Native.knowledge_none());
                     if (this.isVanilla) {
@@ -1015,7 +1015,7 @@ namespace Net.Fenhl.OotAutoTracker {
                     }
                 } else {
                     // OoT ROM detected - check if it's actually a combo ROM via memory context
-                    var version = rom_ident.GetRange(0x15, 3);
+                    var version = rom_ident.Skip(0x15).Take(3).ToList();
                     this.isVanilla = Enumerable.SequenceEqual(version, new List<byte>(new byte[] { 0, 0, 0 }));
 
                     // Check for combo randomizer using multiple detection methods
@@ -1063,7 +1063,7 @@ namespace Net.Fenhl.OotAutoTracker {
 
         public override void UpdateValues(ToolFormUpdateType type) {
             if (type != ToolFormUpdateType.PreFrame) { return; } //TODO setting to also enable auto-tracking during turbo (ToolFormUpdateType.FastPreFrame)?
-            if ((APIs.GameInfo.GetGameInfo()?.Name ?? "Null") == "Null") { return; }
+            if ((APIs.Emulation.GetGameInfo()?.Name ?? "Null") == "Null") { return; }
 
             // For combo mode: periodically re-check which game is active
             if (this.isComboRom && this.detectedGame == GameType.Combo) {

--- a/crate/oottracker-bizhawk/OotAutoTracker/src/Resources/icon.ico
+++ b/crate/oottracker-bizhawk/OotAutoTracker/src/Resources/icon.ico
@@ -1,1 +1,1 @@
-C:/Users/fenhl/git/github.com/fenhl/oottracker/stage/assets/icon.ico
+../../../../../assets/icon.ico


### PR DESCRIPTION
## Summary
- Replace `APIs.GameInfo.GetGameInfo()` with `APIs.Emulation.GetGameInfo()` since GetGameInfo() moved to IEmulationApi in BizHawk 2.11
- Replace `IReadOnlyList<byte>.GetRange(start, count)` with `.Skip(start).Take(count).ToList()` since GetRange doesn't exist on IReadOnlyList
- Fix broken Windows symlink for icon.ico resource

## Test plan
- [ ] Build passes with `dotnet build --configuration=Release` in `crate/oottracker-bizhawk/OotAutoTracker/src/`
- [ ] Test with BizHawk 2.11 to verify the plugin loads correctly
- [ ] Verify OoT/OoTR/MM ROMs are detected properly

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)