### PR TITLE
feat(e2e): Add Lua test harness for E2E control

### DIFF
--- a/assets/oottracker-e2e-harness.lua
+++ b/assets/oottracker-e2e-harness.lua
@@ -1,0 +1,584 @@
+-- OoT Tracker E2E Test Harness for Project64-EM
+-- This script provides emulator control and memory access for automated E2E testing.
+-- It runs alongside the main tracker script (oottracker-pj64em-base.lua).
+
+local VERSION = 1
+
+-- Default port for E2E test harness (different from tracker port)
+local E2E_PORT = 43435
+
+-- RDRAM base address for N64
+local RDRAM_BASE = 0x80000000
+
+-- Command types received from test runner
+local CMD_PING = 0x01
+local CMD_SAVE_STATE = 0x02
+local CMD_LOAD_STATE = 0x03
+local CMD_ADVANCE_FRAMES = 0x04
+local CMD_READ_MEMORY = 0x05
+local CMD_WRITE_MEMORY = 0x06
+local CMD_GET_FRAME_COUNT = 0x07
+local CMD_RESET = 0x08
+local CMD_PAUSE = 0x09
+local CMD_RESUME = 0x0A
+local CMD_SET_INPUT = 0x0B
+
+-- Response types sent to test runner
+local RESP_OK = 0x00
+local RESP_ERROR = 0x01
+local RESP_DATA = 0x02
+local RESP_PONG = 0x03
+
+-- State management
+local serverSocket = nil
+local clientSocket = nil
+local isConnected = false
+local framesToAdvance = 0
+local isPaused = false
+local pendingInput = nil
+local frameCount = 0
+
+-- Save state slots (in-memory state storage for quick save/load)
+local saveStateSlots = {}
+
+-- ============================================================================
+-- Helper Functions
+-- ============================================================================
+
+-- Pack a 32-bit unsigned integer in big-endian format
+local function packU32BE(value)
+    return binary.pack_u8(bit.band(bit.rshift(value, 24), 0xFF)) ..
+           binary.pack_u8(bit.band(bit.rshift(value, 16), 0xFF)) ..
+           binary.pack_u8(bit.band(bit.rshift(value, 8), 0xFF)) ..
+           binary.pack_u8(bit.band(value, 0xFF))
+end
+
+-- Unpack a 32-bit unsigned integer from big-endian bytes
+local function unpackU32BE(b1, b2, b3, b4)
+    return bit.bor(
+        bit.lshift(b1, 24),
+        bit.lshift(b2, 16),
+        bit.lshift(b3, 8),
+        b4
+    )
+end
+
+-- Pack a 16-bit unsigned integer in big-endian format
+local function packU16BE(value)
+    return binary.pack_u8(bit.band(bit.rshift(value, 8), 0xFF)) ..
+           binary.pack_u8(bit.band(value, 0xFF))
+end
+
+-- Unpack a 16-bit unsigned integer from big-endian bytes
+local function unpackU16BE(b1, b2)
+    return bit.bor(bit.lshift(b1, 8), b2)
+end
+
+-- Read a block of memory
+local function readMemoryBlock(addr, size)
+    local data = {}
+    for i = 0, size - 1 do
+        local success, byte = pcall(function()
+            return memory.read_u8(addr + i)
+        end)
+        if success then
+            data[i + 1] = byte
+        else
+            data[i + 1] = 0
+        end
+    end
+    return data
+end
+
+-- Write a block of memory
+local function writeMemoryBlock(addr, data)
+    for i = 1, #data do
+        local success, err = pcall(function()
+            memory.write_u8(addr + i - 1, data[i])
+        end)
+        if not success then
+            return false, "Failed to write at offset " .. (i - 1) .. ": " .. tostring(err)
+        end
+    end
+    return true
+end
+
+-- ============================================================================
+-- Response Builders
+-- ============================================================================
+
+-- Send OK response
+local function sendOk(sock)
+    if not sock then return end
+    local response = binary.pack_u8(RESP_OK)
+    sock:send(response)
+end
+
+-- Send error response with message
+local function sendError(sock, message)
+    if not sock then return end
+    local msgBytes = {string.byte(message, 1, #message)}
+    local response = binary.pack_u8(RESP_ERROR) .. binary.pack_u8(#message)
+    for i = 1, #msgBytes do
+        response = response .. binary.pack_u8(msgBytes[i])
+    end
+    sock:send(response)
+end
+
+-- Send data response
+local function sendData(sock, data)
+    if not sock then return end
+    local response = binary.pack_u8(RESP_DATA) .. packU32BE(#data)
+    for i = 1, #data do
+        response = response .. binary.pack_u8(data[i])
+    end
+    sock:send(response)
+end
+
+-- Send pong response with version
+local function sendPong(sock)
+    if not sock then return end
+    local response = binary.pack_u8(RESP_PONG) .. binary.pack_u8(VERSION)
+    sock:send(response)
+end
+
+-- ============================================================================
+-- Command Handlers
+-- ============================================================================
+
+-- Handle PING command
+local function handlePing(sock)
+    print("[E2E] Received PING")
+    sendPong(sock)
+end
+
+-- Handle SAVE_STATE command
+-- Format: CMD_SAVE_STATE + slot (1 byte)
+local function handleSaveState(sock, slot)
+    print("[E2E] Save state to slot " .. slot)
+
+    -- For PJ64-EM, we use savestate functions if available
+    if emu and emu.savestate then
+        local success, err = pcall(function()
+            emu.savestate(slot)
+        end)
+        if success then
+            sendOk(sock)
+        else
+            sendError(sock, "savestate failed: " .. tostring(err))
+        end
+    else
+        -- Fallback: save RDRAM to internal slot
+        local saveData = {}
+        -- Save critical memory regions (save context + some RAM)
+        local regions = {
+            {0x11A5D0, 0x1450}, -- OoT save context
+            {0x1C8544, 0x0038}, -- OoT scene flags area
+        }
+
+        for _, region in ipairs(regions) do
+            local addr = region[1]
+            local size = region[2]
+            local data = readMemoryBlock(RDRAM_BASE + addr, size)
+            saveData[addr] = data
+        end
+
+        saveStateSlots[slot] = saveData
+        sendOk(sock)
+    end
+end
+
+-- Handle LOAD_STATE command
+-- Format: CMD_LOAD_STATE + slot (1 byte)
+local function handleLoadState(sock, slot)
+    print("[E2E] Load state from slot " .. slot)
+
+    if emu and emu.loadstate then
+        local success, err = pcall(function()
+            emu.loadstate(slot)
+        end)
+        if success then
+            sendOk(sock)
+        else
+            sendError(sock, "loadstate failed: " .. tostring(err))
+        end
+    else
+        -- Fallback: restore from internal slot
+        local saveData = saveStateSlots[slot]
+        if not saveData then
+            sendError(sock, "No save state in slot " .. slot)
+            return
+        end
+
+        for addr, data in pairs(saveData) do
+            writeMemoryBlock(RDRAM_BASE + addr, data)
+        end
+        sendOk(sock)
+    end
+end
+
+-- Handle ADVANCE_FRAMES command
+-- Format: CMD_ADVANCE_FRAMES + frame_count (4 bytes, big-endian)
+local function handleAdvanceFrames(sock, count)
+    print("[E2E] Advance " .. count .. " frames")
+    framesToAdvance = count
+    isPaused = false
+    sendOk(sock)
+end
+
+-- Handle READ_MEMORY command
+-- Format: CMD_READ_MEMORY + address (4 bytes) + size (4 bytes)
+local function handleReadMemory(sock, address, size)
+    print("[E2E] Read " .. size .. " bytes from 0x" .. string.format("%08X", address))
+
+    if size > 65536 then
+        sendError(sock, "Read size too large (max 65536)")
+        return
+    end
+
+    local data = readMemoryBlock(address, size)
+    sendData(sock, data)
+end
+
+-- Handle WRITE_MEMORY command
+-- Format: CMD_WRITE_MEMORY + address (4 bytes) + size (4 bytes) + data
+local function handleWriteMemory(sock, address, data)
+    print("[E2E] Write " .. #data .. " bytes to 0x" .. string.format("%08X", address))
+
+    local success, err = writeMemoryBlock(address, data)
+    if success then
+        sendOk(sock)
+    else
+        sendError(sock, err)
+    end
+end
+
+-- Handle GET_FRAME_COUNT command
+local function handleGetFrameCount(sock)
+    local response = binary.pack_u8(RESP_DATA) .. packU32BE(4) .. packU32BE(frameCount)
+    sock:send(response)
+end
+
+-- Handle RESET command
+local function handleReset(sock)
+    print("[E2E] Reset emulator")
+
+    if emu and emu.reset then
+        local success, err = pcall(function()
+            emu.reset()
+        end)
+        if success then
+            frameCount = 0
+            sendOk(sock)
+        else
+            sendError(sock, "reset failed: " .. tostring(err))
+        end
+    else
+        sendError(sock, "reset not supported")
+    end
+end
+
+-- Handle PAUSE command
+local function handlePause(sock)
+    print("[E2E] Pause emulator")
+    isPaused = true
+
+    if emu and emu.pause then
+        pcall(function() emu.pause() end)
+    end
+
+    sendOk(sock)
+end
+
+-- Handle RESUME command
+local function handleResume(sock)
+    print("[E2E] Resume emulator")
+    isPaused = false
+
+    if emu and emu.unpause then
+        pcall(function() emu.unpause() end)
+    end
+
+    sendOk(sock)
+end
+
+-- Handle SET_INPUT command
+-- Format: CMD_SET_INPUT + controller (1 byte) + buttons (2 bytes) + stick_x (1 byte) + stick_y (1 byte)
+local function handleSetInput(sock, controller, buttons, stickX, stickY)
+    print("[E2E] Set input for controller " .. controller)
+
+    pendingInput = {
+        controller = controller,
+        buttons = buttons,
+        stickX = stickX,
+        stickY = stickY
+    }
+
+    sendOk(sock)
+end
+
+-- ============================================================================
+-- Network Communication
+-- ============================================================================
+
+-- Process incoming data from client
+local function processClientData(sock)
+    -- Try to receive data (non-blocking)
+    local data, err = sock:receive(1)
+    if not data then
+        if err == "timeout" then
+            return true -- No data available, continue
+        end
+        return false -- Connection error
+    end
+
+    local cmd = string.byte(data, 1)
+
+    if cmd == CMD_PING then
+        handlePing(sock)
+
+    elseif cmd == CMD_SAVE_STATE then
+        local slotData = sock:receive(1)
+        if slotData then
+            handleSaveState(sock, string.byte(slotData, 1))
+        end
+
+    elseif cmd == CMD_LOAD_STATE then
+        local slotData = sock:receive(1)
+        if slotData then
+            handleLoadState(sock, string.byte(slotData, 1))
+        end
+
+    elseif cmd == CMD_ADVANCE_FRAMES then
+        local countData = sock:receive(4)
+        if countData then
+            local count = unpackU32BE(
+                string.byte(countData, 1),
+                string.byte(countData, 2),
+                string.byte(countData, 3),
+                string.byte(countData, 4)
+            )
+            handleAdvanceFrames(sock, count)
+        end
+
+    elseif cmd == CMD_READ_MEMORY then
+        local addrSizeData = sock:receive(8)
+        if addrSizeData then
+            local address = unpackU32BE(
+                string.byte(addrSizeData, 1),
+                string.byte(addrSizeData, 2),
+                string.byte(addrSizeData, 3),
+                string.byte(addrSizeData, 4)
+            )
+            local size = unpackU32BE(
+                string.byte(addrSizeData, 5),
+                string.byte(addrSizeData, 6),
+                string.byte(addrSizeData, 7),
+                string.byte(addrSizeData, 8)
+            )
+            handleReadMemory(sock, address, size)
+        end
+
+    elseif cmd == CMD_WRITE_MEMORY then
+        local headerData = sock:receive(8)
+        if headerData then
+            local address = unpackU32BE(
+                string.byte(headerData, 1),
+                string.byte(headerData, 2),
+                string.byte(headerData, 3),
+                string.byte(headerData, 4)
+            )
+            local size = unpackU32BE(
+                string.byte(headerData, 5),
+                string.byte(headerData, 6),
+                string.byte(headerData, 7),
+                string.byte(headerData, 8)
+            )
+
+            if size > 0 and size <= 65536 then
+                local memData = sock:receive(size)
+                if memData then
+                    local dataTable = {}
+                    for i = 1, size do
+                        dataTable[i] = string.byte(memData, i)
+                    end
+                    handleWriteMemory(sock, address, dataTable)
+                end
+            else
+                sendError(sock, "Invalid write size")
+            end
+        end
+
+    elseif cmd == CMD_GET_FRAME_COUNT then
+        handleGetFrameCount(sock)
+
+    elseif cmd == CMD_RESET then
+        handleReset(sock)
+
+    elseif cmd == CMD_PAUSE then
+        handlePause(sock)
+
+    elseif cmd == CMD_RESUME then
+        handleResume(sock)
+
+    elseif cmd == CMD_SET_INPUT then
+        local inputData = sock:receive(5)
+        if inputData then
+            local controller = string.byte(inputData, 1)
+            local buttons = unpackU16BE(
+                string.byte(inputData, 2),
+                string.byte(inputData, 3)
+            )
+            local stickX = string.byte(inputData, 4)
+            local stickY = string.byte(inputData, 5)
+            handleSetInput(sock, controller, buttons, stickX, stickY)
+        end
+
+    else
+        sendError(sock, "Unknown command: " .. cmd)
+    end
+
+    return true
+end
+
+-- Accept new client connection
+local function acceptClient()
+    if not serverSocket then return end
+
+    local client, err = serverSocket:accept()
+    if client then
+        client:settimeout(0) -- Non-blocking
+        clientSocket = client
+        isConnected = true
+        print("[E2E] Test runner connected")
+    end
+end
+
+-- ============================================================================
+-- Frame Callback
+-- ============================================================================
+
+local function onFrame()
+    frameCount = frameCount + 1
+
+    -- Accept new connections if no client
+    if not isConnected then
+        acceptClient()
+    end
+
+    -- Process client commands
+    if clientSocket and isConnected then
+        local success = processClientData(clientSocket)
+        if not success then
+            print("[E2E] Client disconnected")
+            clientSocket:close()
+            clientSocket = nil
+            isConnected = false
+        end
+    end
+
+    -- Handle frame advancement
+    if framesToAdvance > 0 then
+        framesToAdvance = framesToAdvance - 1
+        if framesToAdvance == 0 and emu and emu.pause then
+            -- Pause after advancing requested frames
+            pcall(function() emu.pause() end)
+        end
+    end
+
+    -- Apply pending input
+    if pendingInput and joypad then
+        local success = pcall(function()
+            joypad.set(pendingInput.controller, {
+                A = bit.band(pendingInput.buttons, 0x8000) ~= 0,
+                B = bit.band(pendingInput.buttons, 0x4000) ~= 0,
+                Z = bit.band(pendingInput.buttons, 0x2000) ~= 0,
+                Start = bit.band(pendingInput.buttons, 0x1000) ~= 0,
+                DUp = bit.band(pendingInput.buttons, 0x0800) ~= 0,
+                DDown = bit.band(pendingInput.buttons, 0x0400) ~= 0,
+                DLeft = bit.band(pendingInput.buttons, 0x0200) ~= 0,
+                DRight = bit.band(pendingInput.buttons, 0x0100) ~= 0,
+                L = bit.band(pendingInput.buttons, 0x0020) ~= 0,
+                R = bit.band(pendingInput.buttons, 0x0010) ~= 0,
+                CUp = bit.band(pendingInput.buttons, 0x0008) ~= 0,
+                CDown = bit.band(pendingInput.buttons, 0x0004) ~= 0,
+                CLeft = bit.band(pendingInput.buttons, 0x0002) ~= 0,
+                CRight = bit.band(pendingInput.buttons, 0x0001) ~= 0,
+                X = pendingInput.stickX - 128,
+                Y = pendingInput.stickY - 128
+            })
+        end)
+        -- Clear input after applying (one-shot)
+        pendingInput = nil
+    end
+end
+
+-- ============================================================================
+-- Main Entry Point
+-- ============================================================================
+
+local function main()
+    print("[E2E] OoT Tracker E2E Test Harness v" .. VERSION)
+    print("[E2E] Starting TCP server on port " .. E2E_PORT)
+
+    -- Create TCP server socket
+    local server, err = socket.tcp()
+    if not server then
+        print("[E2E] Failed to create socket: " .. (err or "unknown error"))
+        return
+    end
+
+    -- Allow address reuse
+    server:setoption("reuseaddr", true)
+
+    -- Bind to port
+    local success, bindErr = server:bind("127.0.0.1", E2E_PORT)
+    if not success then
+        print("[E2E] Failed to bind to port " .. E2E_PORT .. ": " .. (bindErr or "unknown error"))
+        server:close()
+        return
+    end
+
+    -- Start listening
+    success, err = server:listen(1)
+    if not success then
+        print("[E2E] Failed to listen: " .. (err or "unknown error"))
+        server:close()
+        return
+    end
+
+    -- Set non-blocking for accept
+    server:settimeout(0)
+    serverSocket = server
+
+    print("[E2E] Server ready, waiting for test runner connection...")
+
+    -- Register frame callback
+    if emu and emu.atvi then
+        emu.atvi(onFrame)
+    elseif events and events.onframeend then
+        events.onframeend(onFrame)
+    else
+        print("[E2E] Warning: No frame callback available, using polling loop")
+        while true do
+            onFrame()
+            -- Small delay to avoid consuming too much CPU
+            if emu and emu.frameadvance then
+                emu.frameadvance()
+            end
+        end
+    end
+end
+
+-- Export functions for use by other scripts
+E2EHarness = {
+    VERSION = VERSION,
+    PORT = E2E_PORT,
+    readMemoryBlock = readMemoryBlock,
+    writeMemoryBlock = writeMemoryBlock,
+    isConnected = function() return isConnected end,
+    getFrameCount = function() return frameCount end
+}
+
+-- Start the harness
+main()

--- a/crate/oottracker-e2e/Cargo.toml
+++ b/crate/oottracker-e2e/Cargo.toml
@@ -10,7 +10,7 @@ thiserror = "1"
 
 [dependencies.tokio]
 version = "1"
-features = ["process", "time", "net", "sync"]
+features = ["process", "time", "net", "sync", "io-util"]
 
 [dev-dependencies.tokio]
 version = "1"

--- a/crate/oottracker-e2e/src/harness.rs
+++ b/crate/oottracker-e2e/src/harness.rs
@@ -1,0 +1,533 @@
+//! TCP client for communicating with the E2E test harness Lua script.
+
+use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::timeout,
+};
+
+/// Default port for E2E test harness (must match Lua script).
+pub const E2E_HARNESS_PORT: u16 = 43435;
+
+/// Command types sent to the Lua harness.
+mod cmd {
+    pub const PING: u8 = 0x01;
+    pub const SAVE_STATE: u8 = 0x02;
+    pub const LOAD_STATE: u8 = 0x03;
+    pub const ADVANCE_FRAMES: u8 = 0x04;
+    pub const READ_MEMORY: u8 = 0x05;
+    pub const WRITE_MEMORY: u8 = 0x06;
+    pub const GET_FRAME_COUNT: u8 = 0x07;
+    pub const RESET: u8 = 0x08;
+    pub const PAUSE: u8 = 0x09;
+    pub const RESUME: u8 = 0x0A;
+    pub const SET_INPUT: u8 = 0x0B;
+}
+
+/// Response types received from the Lua harness.
+mod resp {
+    pub const OK: u8 = 0x00;
+    pub const ERROR: u8 = 0x01;
+    pub const DATA: u8 = 0x02;
+    pub const PONG: u8 = 0x03;
+}
+
+/// Errors that can occur during harness operations.
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    #[error("Failed to connect to harness: {0}")]
+    ConnectionFailed(#[source] std::io::Error),
+
+    #[error("Connection timeout")]
+    ConnectionTimeout,
+
+    #[error("Failed to send command: {0}")]
+    SendFailed(#[source] std::io::Error),
+
+    #[error("Failed to receive response: {0}")]
+    ReceiveFailed(#[source] std::io::Error),
+
+    #[error("Unexpected response type: {0}")]
+    UnexpectedResponse(u8),
+
+    #[error("Harness error: {0}")]
+    HarnessError(String),
+
+    #[error("Operation timeout")]
+    Timeout,
+
+    #[error("Invalid data size: expected {expected}, got {actual}")]
+    InvalidDataSize { expected: usize, actual: usize },
+}
+
+/// Result type for harness operations.
+pub type Result<T> = std::result::Result<T, HarnessError>;
+
+/// N64 controller button flags.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ControllerInput {
+    pub a: bool,
+    pub b: bool,
+    pub z: bool,
+    pub start: bool,
+    pub d_up: bool,
+    pub d_down: bool,
+    pub d_left: bool,
+    pub d_right: bool,
+    pub l: bool,
+    pub r: bool,
+    pub c_up: bool,
+    pub c_down: bool,
+    pub c_left: bool,
+    pub c_right: bool,
+    /// Analog stick X axis (-128 to 127)
+    pub stick_x: i8,
+    /// Analog stick Y axis (-128 to 127)
+    pub stick_y: i8,
+}
+
+impl ControllerInput {
+    /// Converts button states to a 16-bit button mask.
+    fn to_buttons(self) -> u16 {
+        let mut buttons: u16 = 0;
+        if self.a {
+            buttons |= 0x8000;
+        }
+        if self.b {
+            buttons |= 0x4000;
+        }
+        if self.z {
+            buttons |= 0x2000;
+        }
+        if self.start {
+            buttons |= 0x1000;
+        }
+        if self.d_up {
+            buttons |= 0x0800;
+        }
+        if self.d_down {
+            buttons |= 0x0400;
+        }
+        if self.d_left {
+            buttons |= 0x0200;
+        }
+        if self.d_right {
+            buttons |= 0x0100;
+        }
+        if self.l {
+            buttons |= 0x0020;
+        }
+        if self.r {
+            buttons |= 0x0010;
+        }
+        if self.c_up {
+            buttons |= 0x0008;
+        }
+        if self.c_down {
+            buttons |= 0x0004;
+        }
+        if self.c_left {
+            buttons |= 0x0002;
+        }
+        if self.c_right {
+            buttons |= 0x0001;
+        }
+        buttons
+    }
+}
+
+/// Client for communicating with the E2E test harness.
+///
+/// This struct provides methods for controlling the emulator and accessing memory
+/// through the Lua test harness script.
+pub struct HarnessClient {
+    stream: TcpStream,
+    command_timeout: Duration,
+}
+
+impl HarnessClient {
+    /// Connects to the test harness.
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - The TCP port to connect to (default: 43435)
+    /// * `connect_timeout` - Maximum time to wait for connection
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection fails or times out.
+    pub async fn connect(port: u16, connect_timeout: Duration) -> Result<Self> {
+        let addr = format!("127.0.0.1:{}", port);
+
+        let stream = timeout(connect_timeout, TcpStream::connect(&addr))
+            .await
+            .map_err(|_| HarnessError::ConnectionTimeout)?
+            .map_err(HarnessError::ConnectionFailed)?;
+
+        Ok(Self {
+            stream,
+            command_timeout: Duration::from_secs(5),
+        })
+    }
+
+    /// Connects to the test harness on the default port.
+    pub async fn connect_default(connect_timeout: Duration) -> Result<Self> {
+        Self::connect(E2E_HARNESS_PORT, connect_timeout).await
+    }
+
+    /// Sets the command timeout duration.
+    pub fn set_command_timeout(&mut self, timeout: Duration) {
+        self.command_timeout = timeout;
+    }
+
+    /// Sends a ping to verify the connection.
+    ///
+    /// Returns the harness version number.
+    pub async fn ping(&mut self) -> Result<u8> {
+        self.stream
+            .write_all(&[cmd::PING])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        let mut response = [0u8; 2];
+        timeout(self.command_timeout, self.stream.read_exact(&mut response))
+            .await
+            .map_err(|_| HarnessError::Timeout)?
+            .map_err(HarnessError::ReceiveFailed)?;
+
+        if response[0] != resp::PONG {
+            return Err(HarnessError::UnexpectedResponse(response[0]));
+        }
+
+        Ok(response[1])
+    }
+
+    /// Saves emulator state to the specified slot.
+    ///
+    /// # Arguments
+    ///
+    /// * `slot` - The save state slot (0-255)
+    pub async fn save_state(&mut self, slot: u8) -> Result<()> {
+        self.stream
+            .write_all(&[cmd::SAVE_STATE, slot])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Loads emulator state from the specified slot.
+    ///
+    /// # Arguments
+    ///
+    /// * `slot` - The save state slot (0-255)
+    pub async fn load_state(&mut self, slot: u8) -> Result<()> {
+        self.stream
+            .write_all(&[cmd::LOAD_STATE, slot])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Advances the emulator by the specified number of frames.
+    ///
+    /// The emulator will pause after advancing the requested frames.
+    ///
+    /// # Arguments
+    ///
+    /// * `frames` - Number of frames to advance
+    pub async fn advance_frames(&mut self, frames: u32) -> Result<()> {
+        let mut buf = [0u8; 5];
+        buf[0] = cmd::ADVANCE_FRAMES;
+        buf[1..5].copy_from_slice(&frames.to_be_bytes());
+
+        self.stream
+            .write_all(&buf)
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Reads memory from the emulator.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The memory address to read from (N64 address space)
+    /// * `size` - Number of bytes to read (max 65536)
+    ///
+    /// # Returns
+    ///
+    /// The memory contents as a byte vector.
+    pub async fn read_memory(&mut self, address: u32, size: u32) -> Result<Vec<u8>> {
+        let mut buf = [0u8; 9];
+        buf[0] = cmd::READ_MEMORY;
+        buf[1..5].copy_from_slice(&address.to_be_bytes());
+        buf[5..9].copy_from_slice(&size.to_be_bytes());
+
+        self.stream
+            .write_all(&buf)
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_data(size as usize).await
+    }
+
+    /// Writes memory to the emulator.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The memory address to write to (N64 address space)
+    /// * `data` - The data to write
+    pub async fn write_memory(&mut self, address: u32, data: &[u8]) -> Result<()> {
+        let size = data.len() as u32;
+        let mut header = [0u8; 9];
+        header[0] = cmd::WRITE_MEMORY;
+        header[1..5].copy_from_slice(&address.to_be_bytes());
+        header[5..9].copy_from_slice(&size.to_be_bytes());
+
+        self.stream
+            .write_all(&header)
+            .await
+            .map_err(HarnessError::SendFailed)?;
+        self.stream
+            .write_all(data)
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Gets the current frame count.
+    pub async fn get_frame_count(&mut self) -> Result<u32> {
+        self.stream
+            .write_all(&[cmd::GET_FRAME_COUNT])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        let data = self.expect_data(4).await?;
+        Ok(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+    }
+
+    /// Resets the emulator.
+    pub async fn reset(&mut self) -> Result<()> {
+        self.stream
+            .write_all(&[cmd::RESET])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Pauses the emulator.
+    pub async fn pause(&mut self) -> Result<()> {
+        self.stream
+            .write_all(&[cmd::PAUSE])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Resumes the emulator.
+    pub async fn resume(&mut self) -> Result<()> {
+        self.stream
+            .write_all(&[cmd::RESUME])
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Sets controller input for the next frame.
+    ///
+    /// # Arguments
+    ///
+    /// * `controller` - Controller number (0-3)
+    /// * `input` - The controller input state
+    pub async fn set_input(&mut self, controller: u8, input: ControllerInput) -> Result<()> {
+        let buttons = input.to_buttons();
+        let stick_x = (input.stick_x as i16 + 128) as u8;
+        let stick_y = (input.stick_y as i16 + 128) as u8;
+
+        let buf = [
+            cmd::SET_INPUT,
+            controller,
+            (buttons >> 8) as u8,
+            (buttons & 0xFF) as u8,
+            stick_x,
+            stick_y,
+        ];
+
+        self.stream
+            .write_all(&buf)
+            .await
+            .map_err(HarnessError::SendFailed)?;
+
+        self.expect_ok().await
+    }
+
+    /// Reads memory from RDRAM (with automatic base address).
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - Offset within RDRAM
+    /// * `size` - Number of bytes to read
+    pub async fn read_rdram(&mut self, offset: u32, size: u32) -> Result<Vec<u8>> {
+        const RDRAM_BASE: u32 = 0x80000000;
+        self.read_memory(RDRAM_BASE + offset, size).await
+    }
+
+    /// Writes memory to RDRAM (with automatic base address).
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - Offset within RDRAM
+    /// * `data` - The data to write
+    pub async fn write_rdram(&mut self, offset: u32, data: &[u8]) -> Result<()> {
+        const RDRAM_BASE: u32 = 0x80000000;
+        self.write_memory(RDRAM_BASE + offset, data).await
+    }
+
+    /// Waits for an OK response.
+    async fn expect_ok(&mut self) -> Result<()> {
+        let mut response = [0u8; 1];
+        timeout(self.command_timeout, self.stream.read_exact(&mut response))
+            .await
+            .map_err(|_| HarnessError::Timeout)?
+            .map_err(HarnessError::ReceiveFailed)?;
+
+        match response[0] {
+            resp::OK => Ok(()),
+            resp::ERROR => {
+                let mut len_buf = [0u8; 1];
+                self.stream
+                    .read_exact(&mut len_buf)
+                    .await
+                    .map_err(HarnessError::ReceiveFailed)?;
+
+                let len = len_buf[0] as usize;
+                let mut msg_buf = vec![0u8; len];
+                self.stream
+                    .read_exact(&mut msg_buf)
+                    .await
+                    .map_err(HarnessError::ReceiveFailed)?;
+
+                let msg = String::from_utf8_lossy(&msg_buf).to_string();
+                Err(HarnessError::HarnessError(msg))
+            }
+            other => Err(HarnessError::UnexpectedResponse(other)),
+        }
+    }
+
+    /// Waits for a DATA response.
+    async fn expect_data(&mut self, expected_size: usize) -> Result<Vec<u8>> {
+        let mut response = [0u8; 5];
+        timeout(self.command_timeout, self.stream.read_exact(&mut response))
+            .await
+            .map_err(|_| HarnessError::Timeout)?
+            .map_err(HarnessError::ReceiveFailed)?;
+
+        match response[0] {
+            resp::DATA => {
+                let size = u32::from_be_bytes([response[1], response[2], response[3], response[4]])
+                    as usize;
+
+                if size != expected_size {
+                    return Err(HarnessError::InvalidDataSize {
+                        expected: expected_size,
+                        actual: size,
+                    });
+                }
+
+                let mut data = vec![0u8; size];
+                timeout(self.command_timeout, self.stream.read_exact(&mut data))
+                    .await
+                    .map_err(|_| HarnessError::Timeout)?
+                    .map_err(HarnessError::ReceiveFailed)?;
+
+                Ok(data)
+            }
+            resp::ERROR => {
+                let mut remaining = [0u8; 1];
+                self.stream
+                    .read_exact(&mut remaining)
+                    .await
+                    .map_err(HarnessError::ReceiveFailed)?;
+
+                let len = remaining[0] as usize;
+                let mut msg_buf = vec![0u8; len];
+                self.stream
+                    .read_exact(&mut msg_buf)
+                    .await
+                    .map_err(HarnessError::ReceiveFailed)?;
+
+                let msg = String::from_utf8_lossy(&msg_buf).to_string();
+                Err(HarnessError::HarnessError(msg))
+            }
+            other => Err(HarnessError::UnexpectedResponse(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_controller_input_default() {
+        let input = ControllerInput::default();
+        assert_eq!(input.to_buttons(), 0);
+        assert_eq!(input.stick_x, 0);
+        assert_eq!(input.stick_y, 0);
+    }
+
+    #[test]
+    fn test_controller_input_buttons() {
+        let input = ControllerInput {
+            a: true,
+            b: true,
+            z: true,
+            start: true,
+            ..Default::default()
+        };
+        assert_eq!(input.to_buttons(), 0xF000);
+    }
+
+    #[test]
+    fn test_controller_input_c_buttons() {
+        let input = ControllerInput {
+            c_up: true,
+            c_down: true,
+            c_left: true,
+            c_right: true,
+            ..Default::default()
+        };
+        assert_eq!(input.to_buttons(), 0x000F);
+    }
+
+    #[test]
+    fn test_controller_input_all_buttons() {
+        let input = ControllerInput {
+            a: true,
+            b: true,
+            z: true,
+            start: true,
+            d_up: true,
+            d_down: true,
+            d_left: true,
+            d_right: true,
+            l: true,
+            r: true,
+            c_up: true,
+            c_down: true,
+            c_left: true,
+            c_right: true,
+            stick_x: 0,
+            stick_y: 0,
+        };
+        assert_eq!(input.to_buttons(), 0xFF3F);
+    }
+}

--- a/crate/oottracker-e2e/src/launcher.rs
+++ b/crate/oottracker-e2e/src/launcher.rs
@@ -45,6 +45,7 @@ pub type Result<T> = std::result::Result<T, LauncherError>;
 pub struct Pj64EmLauncher {
     wine_prefix: PathBuf,
     pj64_exe: PathBuf,
+    lua_scripts: Vec<PathBuf>,
     process: Option<Child>,
 }
 
@@ -59,8 +60,32 @@ impl Pj64EmLauncher {
         Self {
             wine_prefix,
             pj64_exe,
+            lua_scripts: Vec::new(),
             process: None,
         }
+    }
+
+    /// Adds a Lua script to be loaded when launching.
+    ///
+    /// Scripts are loaded in the order they are added.
+    ///
+    /// # Arguments
+    ///
+    /// * `script_path` - Path to the Lua script file
+    pub fn add_lua_script(&mut self, script_path: PathBuf) -> &mut Self {
+        self.lua_scripts.push(script_path);
+        self
+    }
+
+    /// Clears all configured Lua scripts.
+    pub fn clear_lua_scripts(&mut self) -> &mut Self {
+        self.lua_scripts.clear();
+        self
+    }
+
+    /// Returns the list of configured Lua scripts.
+    pub fn lua_scripts(&self) -> &[PathBuf] {
+        &self.lua_scripts
     }
 
     /// Launches Project64-EM with the specified ROM.
@@ -89,9 +114,19 @@ impl Pj64EmLauncher {
             return Err(LauncherError::Pj64NotFound(self.pj64_exe.clone()));
         }
 
-        let child = Command::new("wine")
-            .arg(&self.pj64_exe)
-            .arg(rom)
+        let mut cmd = Command::new("wine");
+        cmd.arg(&self.pj64_exe);
+
+        // Add Lua scripts with --lua flag
+        for script in &self.lua_scripts {
+            cmd.arg("--lua");
+            cmd.arg(script);
+        }
+
+        // Add the ROM as the final argument
+        cmd.arg(rom);
+
+        let child = cmd
             // Required for 512MB RDRAM allocation
             .env("WINEPREFIX", &self.wine_prefix)
             // Performance settings - disable vsync
@@ -229,7 +264,32 @@ mod tests {
 
         assert_eq!(launcher.wine_prefix(), wine_prefix);
         assert_eq!(launcher.pj64_exe(), pj64_exe);
-        assert!(!launcher.process.is_some());
+        assert!(launcher.lua_scripts().is_empty());
+        assert!(launcher.process.is_none());
+    }
+
+    #[test]
+    fn test_launcher_lua_scripts() {
+        let wine_prefix = PathBuf::from("/home/test/.wine");
+        let pj64_exe = PathBuf::from("/home/test/pj64/Project64.exe");
+
+        let mut launcher = Pj64EmLauncher::new(wine_prefix, pj64_exe);
+
+        launcher.add_lua_script(PathBuf::from("/path/to/harness.lua"));
+        launcher.add_lua_script(PathBuf::from("/path/to/tracker.lua"));
+
+        assert_eq!(launcher.lua_scripts().len(), 2);
+        assert_eq!(
+            launcher.lua_scripts()[0],
+            PathBuf::from("/path/to/harness.lua")
+        );
+        assert_eq!(
+            launcher.lua_scripts()[1],
+            PathBuf::from("/path/to/tracker.lua")
+        );
+
+        launcher.clear_lua_scripts();
+        assert!(launcher.lua_scripts().is_empty());
     }
 
     #[tokio::test]

--- a/crate/oottracker-e2e/src/lib.rs
+++ b/crate/oottracker-e2e/src/lib.rs
@@ -3,7 +3,14 @@
 //! This crate provides tools for running automated end-to-end tests,
 //! including a Wine+PJ64-EM process launcher for testing against
 //! real emulator instances.
+//!
+//! ## Components
+//!
+//! - [`launcher`]: Wine+PJ64-EM process management
+//! - [`harness`]: TCP client for controlling the emulator via Lua test harness
 
+pub mod harness;
 pub mod launcher;
 
-pub use launcher::{LauncherError, Pj64EmLauncher, Result};
+pub use harness::{ControllerInput, HarnessClient, HarnessError, E2E_HARNESS_PORT};
+pub use launcher::{LauncherError, Pj64EmLauncher};


### PR DESCRIPTION
## Summary
- Add Lua test harness script (584 lines) for controlling E2E tests in Project64-EM
- Add Rust harness module (533 lines) for test runner communication
- Provides emulator state control, memory access, and TCP communication with test runner

Closes #366

## Test plan
- [x] `cargo test -p oottracker-e2e` passes
- [x] `cargo clippy` clean
- [ ] Harness loads alongside tracker script in Project64-EM

🤖 Generated with [Claude Code](https://claude.com/claude-code)