### PR TITLE
feat(web): Add settings configuration UI component

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -18,6 +18,7 @@
                 <button type="submit" value="Go" name="submit_open_room_form">Go</button>
             </form>
             <p>Or, <a href="https://github.com/fenhl/oottracker#readme">download the tracker</a> for Windows or macOS.</p>
+            <p><a href="/settings">Configure randomizer settings</a></p>
             <footer>
                 version {} • <a href="https://github.com/fenhl/oottracker">source code</a> • <a href="https://fenhl.net/disc">disclaimer / Impressum</a>
             </footer>

--- a/assets/web/settings.html
+++ b/assets/web/settings.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>OoTMM Tracker Settings</title>
+        <meta name="author" content="Fenhl" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" sizes="512x512" type="image/png" href="/static/img/favicon.png" />
+        <link rel="stylesheet" href="/static/common.css" />
+        <link rel="stylesheet" href="/static/settings.css" />
+        <link rel="stylesheet" href="/static/light.css" media="(prefers-color-scheme: light)" />
+    </head>
+    <body>
+        <div class="settings-container">
+            <h1>OoTMM Tracker Settings</h1>
+            <p class="subtitle">Configure randomizer settings for logic evaluation</p>
+
+            <form id="settings-form">
+                <!-- Logic Mode Section -->
+                <section class="settings-section">
+                    <h2>Logic Mode</h2>
+                    <div class="setting-group">
+                        <label for="logicMode">Logic Rules</label>
+                        <select id="logicMode" name="logicMode">
+                            <option value="glitchless">Glitchless</option>
+                            <option value="glitched">Glitched</option>
+                            <option value="noLogic">No Logic</option>
+                        </select>
+                        <span class="setting-description">Determines what logic rules are used for check evaluation</span>
+                    </div>
+                </section>
+
+                <!-- Open Dungeons OoT Section -->
+                <section class="settings-section">
+                    <h2>Open Dungeons (OoT)</h2>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="DC" />
+                            <span>Dodongo's Cavern (DC)</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="BotW" />
+                            <span>Bottom of the Well (BotW)</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="JJ" />
+                            <span>Jabu-Jabu's Belly (JJ)</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="Shadow" />
+                            <span>Shadow Temple</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="Water" />
+                            <span>Water Temple</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="fireChild" />
+                            <span>Fire Temple (Child Access)</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsOot" value="wellAdult" />
+                            <span>Well (Adult Access)</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- Open Dungeons MM Section -->
+                <section class="settings-section">
+                    <h2>Open Dungeons (MM)</h2>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsMm" value="ST" />
+                            <span>Stone Tower Temple (ST)</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openDungeonsMm" value="WF" />
+                            <span>Woodfall Temple (WF)</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- World State Settings Section -->
+                <section class="settings-section">
+                    <h2>World State</h2>
+
+                    <div class="setting-group">
+                        <label for="dekuTree">Deku Tree</label>
+                        <select id="dekuTree" name="dekuTree">
+                            <option value="closed">Closed</option>
+                            <option value="open">Open</option>
+                            <option value="vanilla">Vanilla</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="doorOfTime">Door of Time</label>
+                        <select id="doorOfTime" name="doorOfTime">
+                            <option value="closed">Closed</option>
+                            <option value="open">Open</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="kakarikoGate">Kakariko Gate</label>
+                        <select id="kakarikoGate" name="kakarikoGate">
+                            <option value="closed">Closed</option>
+                            <option value="open">Open</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="ganonBossKey">Ganon's Boss Key</label>
+                        <select id="ganonBossKey" name="ganonBossKey">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="removed">Removed</option>
+                            <option value="custom">Custom</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="lacs">Light Arrow Cutscene (LACS)</label>
+                        <select id="lacs" name="lacs">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="custom">Custom</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="beneathWell">Beneath the Well</label>
+                        <select id="beneathWell" name="beneathWell">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="open">Open</option>
+                        </select>
+                    </div>
+                </section>
+
+                <!-- MM Settings Section -->
+                <section class="settings-section">
+                    <h2>Majora's Mask Settings</h2>
+
+                    <div class="setting-group">
+                        <label for="majoraChild">Majora Child Mode</label>
+                        <select id="majoraChild" name="majoraChild">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="none">None</option>
+                            <option value="custom">Custom</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="moonCrash">Moon Crash</label>
+                        <select id="moonCrash" name="moonCrash">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="cycle">Cycle</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="bossWarpPads">Boss Warp Pads</label>
+                        <select id="bossWarpPads" name="bossWarpPads">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="remains">Requires Remains</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="shufflePotsMm">Shuffle Pots (MM)</label>
+                        <select id="shufflePotsMm" name="shufflePotsMm">
+                            <option value="none">None</option>
+                            <option value="all">All</option>
+                        </select>
+                    </div>
+                </section>
+
+                <!-- Age & Time Settings Section -->
+                <section class="settings-section">
+                    <h2>Age & Time Settings</h2>
+
+                    <div class="setting-group">
+                        <label for="ageChange">Age Change Mode</label>
+                        <select id="ageChange" name="ageChange">
+                            <option value="templeOfTime">Temple of Time</option>
+                            <option value="none">None</option>
+                            <option value="oot">OoT Style</option>
+                        </select>
+                    </div>
+                </section>
+
+                <!-- Ageless Items Section -->
+                <section class="settings-section">
+                    <h2>Ageless Items</h2>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agelessBoots" />
+                            <span>Ageless Boots</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agelessHookshot" />
+                            <span>Ageless Hookshot</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agelessStrength" />
+                            <span>Ageless Strength</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- Entrance Randomizer Section -->
+                <section class="settings-section">
+                    <h2>Entrance Randomizer</h2>
+
+                    <div class="setting-group">
+                        <label for="erOverworld">Overworld ER</label>
+                        <select id="erOverworld" name="erOverworld">
+                            <option value="none">None</option>
+                            <option value="full">Full</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="erGrottos">Grottos ER</label>
+                        <select id="erGrottos" name="erGrottos">
+                            <option value="none">None</option>
+                            <option value="full">Full</option>
+                        </select>
+                    </div>
+
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="erIndoorsMajor" />
+                            <span>Indoors Major</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="erIndoorsExtra" />
+                            <span>Indoors Extra</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="erIndoorsGameLinks" />
+                            <span>Indoors Game Links</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="erMoon" />
+                            <span>Moon</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- Key Shuffle Section -->
+                <section class="settings-section">
+                    <h2>Key Shuffle</h2>
+
+                    <div class="setting-group">
+                        <label for="smallKeyShuffleOot">Small Key Shuffle (OoT)</label>
+                        <select id="smallKeyShuffleOot" name="smallKeyShuffleOot">
+                            <option value="vanilla">Vanilla</option>
+                            <option value="dungeon">Within Dungeon</option>
+                            <option value="anywhere">Anywhere</option>
+                        </select>
+                    </div>
+                </section>
+
+                <!-- Other Settings Section -->
+                <section class="settings-section">
+                    <h2>Other Settings</h2>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="skipZelda" />
+                            <span>Skip Child Zelda</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="timeTravelSword" />
+                            <span>Time Travel Requires Sword</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openMaskShop" />
+                            <span>Open Mask Shop</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openMoon" />
+                            <span>Open Moon</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="openZdShortcut" />
+                            <span>Open Zora's Domain Shortcut</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="alterLostWoodsExits" />
+                            <span>Alter Lost Woods Exits</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="pondFishShuffle" />
+                            <span>Pond Fish Shuffle</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="restoreBrokenActors" />
+                            <span>Restore Broken Actors</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- Glitch Settings Section -->
+                <section class="settings-section">
+                    <h2>Glitch Settings (OoT)</h2>
+
+                    <div class="setting-group">
+                        <label for="climbMostSurfacesOot">Climb Most Surfaces</label>
+                        <select id="climbMostSurfacesOot" name="climbMostSurfacesOot">
+                            <option value="on">On</option>
+                            <option value="off">Off</option>
+                        </select>
+                    </div>
+
+                    <div class="setting-group">
+                        <label for="hookshotAnywhereOot">Hookshot Anywhere</label>
+                        <select id="hookshotAnywhereOot" name="hookshotAnywhereOot">
+                            <option value="on">On</option>
+                            <option value="off">Off</option>
+                        </select>
+                    </div>
+                </section>
+
+                <!-- Logic Tricks Section -->
+                <section class="settings-section">
+                    <h2>Logic Tricks</h2>
+                    <div class="setting-group">
+                        <label for="logicTricks">Enabled Tricks (comma-separated)</label>
+                        <textarea id="logicTricks" name="logicTricks" placeholder="e.g., hover_boost, damage_boost_simple"></textarea>
+                        <span class="setting-description">Enter trick names separated by commas</span>
+                    </div>
+                </section>
+
+                <!-- Action Buttons -->
+                <div class="button-group">
+                    <button type="button" id="loadSettings">Load from File</button>
+                    <button type="button" id="saveSettings">Save to File</button>
+                    <button type="button" id="resetSettings">Reset to Defaults</button>
+                    <button type="button" id="copyJson">Copy as JSON</button>
+                </div>
+
+                <input type="file" id="fileInput" accept=".json" style="display: none;" />
+            </form>
+
+            <div id="status-message" class="status-message"></div>
+
+            <footer>
+                <a href="/">Back to Tracker</a> |
+                <a href="https://github.com/fenhl/oottracker">Source Code</a> |
+                <a href="https://fenhl.net/disc">Disclaimer / Impressum</a>
+            </footer>
+        </div>
+
+        <script src="/static/settings.js"></script>
+    </body>
+</html>

--- a/assets/web/static/settings.css
+++ b/assets/web/static/settings.css
@@ -1,0 +1,265 @@
+/* OoTMM Tracker Settings Styles */
+
+.settings-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.settings-container h1 {
+    text-align: center;
+    margin-bottom: 10px;
+    color: #00bb44;
+}
+
+.settings-container .subtitle {
+    text-align: center;
+    color: #888;
+    margin-bottom: 30px;
+}
+
+/* Section styling */
+.settings-section {
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+}
+
+.settings-section h2 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    font-size: 1.2rem;
+    color: #00bb44;
+}
+
+/* Setting group (label + input) */
+.setting-group {
+    margin-bottom: 15px;
+}
+
+.setting-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
+}
+
+.setting-group select,
+.setting-group textarea {
+    width: 100%;
+    padding: 10px;
+    background-color: #1a1a1a;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: white;
+    font-size: 14px;
+}
+
+.setting-group select:focus,
+.setting-group textarea:focus {
+    outline: none;
+    border-color: #00bb44;
+}
+
+.setting-group textarea {
+    min-height: 60px;
+    resize: vertical;
+    font-family: monospace;
+}
+
+.setting-description {
+    display: block;
+    margin-top: 5px;
+    font-size: 12px;
+    color: #888;
+}
+
+/* Checkbox groups */
+.checkbox-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 10px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.checkbox-label:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.checkbox-label input[type="checkbox"] {
+    margin-right: 10px;
+    width: 18px;
+    height: 18px;
+    accent-color: #00bb44;
+    cursor: pointer;
+}
+
+.checkbox-label span {
+    user-select: none;
+}
+
+/* Button group */
+.button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.button-group button {
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: all 0.2s;
+}
+
+#saveSettings {
+    background-color: #00bb44;
+    border: none;
+    color: white;
+}
+
+#saveSettings:hover {
+    background-color: #00dd55;
+}
+
+#loadSettings {
+    background-color: #2563eb;
+    border: none;
+    color: white;
+}
+
+#loadSettings:hover {
+    background-color: #3b82f6;
+}
+
+#resetSettings {
+    background-color: #dc2626;
+    border: none;
+    color: white;
+}
+
+#resetSettings:hover {
+    background-color: #ef4444;
+}
+
+#copyJson {
+    background-color: #7c3aed;
+    border: none;
+    color: white;
+}
+
+#copyJson:hover {
+    background-color: #8b5cf6;
+}
+
+/* Status message */
+.status-message {
+    display: none;
+    text-align: center;
+    padding: 12px 20px;
+    margin-top: 20px;
+    border-radius: 6px;
+    font-weight: 500;
+}
+
+.status-message.success {
+    background-color: rgba(0, 187, 68, 0.2);
+    border: 1px solid #00bb44;
+    color: #00bb44;
+}
+
+.status-message.error {
+    background-color: rgba(220, 38, 38, 0.2);
+    border: 1px solid #dc2626;
+    color: #ef4444;
+}
+
+.status-message.info {
+    background-color: rgba(37, 99, 235, 0.2);
+    border: 1px solid #2563eb;
+    color: #3b82f6;
+}
+
+/* Footer styling */
+.settings-container footer {
+    margin-top: 30px;
+    padding-top: 20px;
+    text-align: center;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.settings-container footer a {
+    color: #00bb44;
+    text-decoration: none;
+}
+
+.settings-container footer a:hover {
+    text-decoration: underline;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .settings-container {
+        padding: 10px;
+    }
+
+    .checkbox-group {
+        grid-template-columns: 1fr;
+    }
+
+    .button-group {
+        flex-direction: column;
+    }
+
+    .button-group button {
+        width: 100%;
+    }
+}
+
+/* Light mode overrides */
+@media (prefers-color-scheme: light) {
+    .settings-section {
+        background-color: rgba(0, 0, 0, 0.03);
+        border-color: rgba(0, 0, 0, 0.1);
+    }
+
+    .settings-section h2 {
+        border-bottom-color: rgba(0, 0, 0, 0.1);
+    }
+
+    .setting-group select,
+    .setting-group textarea {
+        background-color: white;
+        border-color: #ccc;
+        color: black;
+    }
+
+    .checkbox-label:hover {
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .button-group {
+        border-top-color: rgba(0, 0, 0, 0.1);
+    }
+
+    .settings-container footer {
+        border-top-color: rgba(0, 0, 0, 0.1);
+    }
+}

--- a/assets/web/static/settings.js
+++ b/assets/web/static/settings.js
@@ -1,0 +1,327 @@
+/**
+ * OoTMM Tracker Settings UI
+ *
+ * This module handles the settings configuration UI for the OoTMM randomizer tracker.
+ * It provides functionality to load, save, and manage RandomizerSettings.
+ */
+
+// Default settings matching RandomizerSettings::default() in Rust
+const DEFAULT_SETTINGS = {
+    // Boolean settings
+    agelessBoots: false,
+    agelessHookshot: false,
+    agelessStrength: false,
+    alterLostWoodsExits: false,
+    erIndoorsExtra: false,
+    erIndoorsGameLinks: false,
+    erIndoorsMajor: false,
+    erMoon: false,
+    openMaskShop: false,
+    openMoon: false,
+    openZdShortcut: false,
+    pondFishShuffle: false,
+    restoreBrokenActors: false,
+    skipZelda: false,
+    timeTravelSword: false,
+
+    // Set settings (arrays)
+    openDungeonsOot: [],
+    openDungeonsMm: [],
+    clearStateDungeonsMm: [],
+    jpLayouts: [],
+    logicTricks: [],
+
+    // Enum settings
+    dekuTree: 'closed',
+    doorOfTime: 'closed',
+    kakarikoGate: 'closed',
+    ganonBossKey: 'vanilla',
+    lacs: 'vanilla',
+    majoraChild: 'vanilla',
+    moonCrash: 'vanilla',
+    ageChange: 'templeOfTime',
+    climbMostSurfacesOot: 'on',
+    hookshotAnywhereOot: 'on',
+    beneathWell: 'vanilla',
+    erOverworld: 'none',
+    erGrottos: 'none',
+    bossWarpPads: 'vanilla',
+    smallKeyShuffleOot: 'vanilla',
+    shufflePotsMm: 'none',
+    logicMode: 'glitchless'
+};
+
+/**
+ * Gets the current settings from the form as a JSON object.
+ * @returns {Object} The current settings
+ */
+function getSettingsFromForm() {
+    const form = document.getElementById('settings-form');
+    const settings = { ...DEFAULT_SETTINGS };
+
+    // Boolean checkboxes
+    const booleanFields = [
+        'agelessBoots', 'agelessHookshot', 'agelessStrength',
+        'alterLostWoodsExits', 'erIndoorsExtra', 'erIndoorsGameLinks',
+        'erIndoorsMajor', 'erMoon', 'openMaskShop', 'openMoon',
+        'openZdShortcut', 'pondFishShuffle', 'restoreBrokenActors',
+        'skipZelda', 'timeTravelSword'
+    ];
+
+    booleanFields.forEach(field => {
+        const checkbox = form.querySelector(`input[name="${field}"]`);
+        if (checkbox) {
+            settings[field] = checkbox.checked;
+        }
+    });
+
+    // Multi-value checkboxes (sets)
+    settings.openDungeonsOot = Array.from(form.querySelectorAll('input[name="openDungeonsOot"]:checked'))
+        .map(cb => cb.value);
+    settings.openDungeonsMm = Array.from(form.querySelectorAll('input[name="openDungeonsMm"]:checked'))
+        .map(cb => cb.value);
+
+    // Select dropdowns
+    const selectFields = [
+        'logicMode', 'dekuTree', 'doorOfTime', 'kakarikoGate',
+        'ganonBossKey', 'lacs', 'majoraChild', 'moonCrash',
+        'ageChange', 'climbMostSurfacesOot', 'hookshotAnywhereOot',
+        'beneathWell', 'erOverworld', 'erGrottos', 'bossWarpPads',
+        'smallKeyShuffleOot', 'shufflePotsMm'
+    ];
+
+    selectFields.forEach(field => {
+        const select = form.querySelector(`select[name="${field}"]`);
+        if (select) {
+            settings[field] = select.value;
+        }
+    });
+
+    // Logic tricks (comma-separated textarea)
+    const tricksTextarea = form.querySelector('textarea[name="logicTricks"]');
+    if (tricksTextarea && tricksTextarea.value.trim()) {
+        settings.logicTricks = tricksTextarea.value
+            .split(',')
+            .map(trick => trick.trim())
+            .filter(trick => trick.length > 0);
+    } else {
+        settings.logicTricks = [];
+    }
+
+    return settings;
+}
+
+/**
+ * Populates the form with settings values.
+ * @param {Object} settings The settings object to populate from
+ */
+function populateForm(settings) {
+    const form = document.getElementById('settings-form');
+    const merged = { ...DEFAULT_SETTINGS, ...settings };
+
+    // Boolean checkboxes
+    const booleanFields = [
+        'agelessBoots', 'agelessHookshot', 'agelessStrength',
+        'alterLostWoodsExits', 'erIndoorsExtra', 'erIndoorsGameLinks',
+        'erIndoorsMajor', 'erMoon', 'openMaskShop', 'openMoon',
+        'openZdShortcut', 'pondFishShuffle', 'restoreBrokenActors',
+        'skipZelda', 'timeTravelSword'
+    ];
+
+    booleanFields.forEach(field => {
+        const checkbox = form.querySelector(`input[name="${field}"]`);
+        if (checkbox) {
+            checkbox.checked = merged[field] || false;
+        }
+    });
+
+    // Multi-value checkboxes (sets)
+    const dungeonOot = merged.openDungeonsOot || [];
+    form.querySelectorAll('input[name="openDungeonsOot"]').forEach(cb => {
+        cb.checked = dungeonOot.includes(cb.value);
+    });
+
+    const dungeonMm = merged.openDungeonsMm || [];
+    form.querySelectorAll('input[name="openDungeonsMm"]').forEach(cb => {
+        cb.checked = dungeonMm.includes(cb.value);
+    });
+
+    // Select dropdowns
+    const selectFields = [
+        'logicMode', 'dekuTree', 'doorOfTime', 'kakarikoGate',
+        'ganonBossKey', 'lacs', 'majoraChild', 'moonCrash',
+        'ageChange', 'climbMostSurfacesOot', 'hookshotAnywhereOot',
+        'beneathWell', 'erOverworld', 'erGrottos', 'bossWarpPads',
+        'smallKeyShuffleOot', 'shufflePotsMm'
+    ];
+
+    selectFields.forEach(field => {
+        const select = form.querySelector(`select[name="${field}"]`);
+        if (select && merged[field]) {
+            select.value = merged[field];
+        }
+    });
+
+    // Logic tricks
+    const tricksTextarea = form.querySelector('textarea[name="logicTricks"]');
+    if (tricksTextarea) {
+        const tricks = merged.logicTricks || [];
+        tricksTextarea.value = tricks.join(', ');
+    }
+}
+
+/**
+ * Shows a status message to the user.
+ * @param {string} message The message to display
+ * @param {string} type The type of message ('success', 'error', 'info')
+ */
+function showStatus(message, type = 'info') {
+    const statusEl = document.getElementById('status-message');
+    if (statusEl) {
+        statusEl.textContent = message;
+        statusEl.className = `status-message ${type}`;
+        statusEl.style.display = 'block';
+
+        // Auto-hide after 3 seconds
+        setTimeout(() => {
+            statusEl.style.display = 'none';
+        }, 3000);
+    }
+}
+
+/**
+ * Saves settings to a JSON file (download).
+ */
+function saveSettingsToFile() {
+    try {
+        const settings = getSettingsFromForm();
+        const json = JSON.stringify(settings, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'ootmm-settings.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        showStatus('Settings saved to file', 'success');
+    } catch (error) {
+        console.error('Error saving settings:', error);
+        showStatus('Error saving settings: ' + error.message, 'error');
+    }
+}
+
+/**
+ * Loads settings from a JSON file.
+ */
+function loadSettingsFromFile() {
+    const fileInput = document.getElementById('fileInput');
+    fileInput.click();
+}
+
+/**
+ * Handles file input change event.
+ * @param {Event} event The change event
+ */
+function handleFileLoad(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        try {
+            const settings = JSON.parse(e.target.result);
+            populateForm(settings);
+            showStatus('Settings loaded from file', 'success');
+        } catch (error) {
+            console.error('Error loading settings:', error);
+            showStatus('Error loading settings: Invalid JSON file', 'error');
+        }
+    };
+    reader.readAsText(file);
+
+    // Reset file input so the same file can be loaded again
+    event.target.value = '';
+}
+
+/**
+ * Resets all settings to defaults.
+ */
+function resetSettings() {
+    if (confirm('Are you sure you want to reset all settings to defaults?')) {
+        populateForm(DEFAULT_SETTINGS);
+        showStatus('Settings reset to defaults', 'success');
+    }
+}
+
+/**
+ * Copies current settings to clipboard as JSON.
+ */
+async function copySettingsAsJson() {
+    try {
+        const settings = getSettingsFromForm();
+        const json = JSON.stringify(settings, null, 2);
+        await navigator.clipboard.writeText(json);
+        showStatus('Settings copied to clipboard', 'success');
+    } catch (error) {
+        console.error('Error copying settings:', error);
+        showStatus('Error copying settings: ' + error.message, 'error');
+    }
+}
+
+/**
+ * Saves settings to localStorage.
+ */
+function saveToLocalStorage() {
+    try {
+        const settings = getSettingsFromForm();
+        localStorage.setItem('ootmm-settings', JSON.stringify(settings));
+    } catch (error) {
+        console.error('Error saving to localStorage:', error);
+    }
+}
+
+/**
+ * Loads settings from localStorage.
+ */
+function loadFromLocalStorage() {
+    try {
+        const saved = localStorage.getItem('ootmm-settings');
+        if (saved) {
+            const settings = JSON.parse(saved);
+            populateForm(settings);
+            return true;
+        }
+    } catch (error) {
+        console.error('Error loading from localStorage:', error);
+    }
+    return false;
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+    // Load settings from localStorage if available
+    if (!loadFromLocalStorage()) {
+        // Otherwise use defaults
+        populateForm(DEFAULT_SETTINGS);
+    }
+
+    // Set up event listeners
+    document.getElementById('saveSettings').addEventListener('click', saveSettingsToFile);
+    document.getElementById('loadSettings').addEventListener('click', loadSettingsFromFile);
+    document.getElementById('resetSettings').addEventListener('click', resetSettings);
+    document.getElementById('copyJson').addEventListener('click', copySettingsAsJson);
+    document.getElementById('fileInput').addEventListener('change', handleFileLoad);
+
+    // Auto-save to localStorage on any form change
+    const form = document.getElementById('settings-form');
+    form.addEventListener('change', saveToLocalStorage);
+    form.addEventListener('input', function(e) {
+        if (e.target.tagName === 'TEXTAREA') {
+            saveToLocalStorage();
+        }
+    });
+});

--- a/crate/oottracker-web/src/http.rs
+++ b/crate/oottracker-web/src/http.rs
@@ -104,6 +104,11 @@ fn index() -> RawHtml<String> {
     ))
 }
 
+#[rocket::get("/settings")]
+fn settings() -> RawHtml<String> {
+    RawHtml(include_str!("../../../assets/web/settings.html").to_owned())
+}
+
 #[derive(FromForm)]
 struct GoRoomForm<'r> {
     #[field(validate = len(1..))]
@@ -466,6 +471,7 @@ pub(crate) fn rocket(
         rocket::routes![
             index,
             post_index,
+            settings,
             mw_room_input,
             mw_room_view,
             mw_click,
@@ -514,6 +520,7 @@ mod tests {
             rocket::routes![
                 index,
                 post_index,
+                settings,
                 mw_room_input,
                 mw_room_view,
                 mw_click,
@@ -572,6 +579,40 @@ mod tests {
         assert!(body.contains(r#"method="POST""#));
         assert!(body.contains(r#"action="/""#));
         assert!(body.contains(r#"name="room""#));
+    }
+
+    // ==========================================================================
+    // Settings Route Tests
+    // ==========================================================================
+
+    #[rocket::async_test]
+    async fn test_settings_returns_html() {
+        let client = Client::tracked(test_rocket().await)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/settings").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        assert!(body.contains("OoTMM Tracker Settings"));
+        assert!(body.contains("<html>"));
+    }
+
+    #[rocket::async_test]
+    async fn test_settings_contains_form_elements() {
+        let client = Client::tracked(test_rocket().await)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/settings").dispatch().await;
+        let body = response.into_string().await.expect("response body");
+
+        // Verify key form elements are present
+        assert!(body.contains(r#"id="settings-form""#));
+        assert!(body.contains(r#"name="logicMode""#));
+        assert!(body.contains(r#"name="openDungeonsOot""#));
+        assert!(body.contains(r#"name="agelessBoots""#));
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary
- Adds settings.html page with form sections for all OoTMM randomizer settings
- Adds settings.js for load/save to JSON and localStorage persistence
- Adds settings.css with responsive styling and dark/light mode support
- Integrates with RandomizerSettings schema from ootmm crate

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>