### PR TITLE
feat(web): Wire up checked locations to tracker UI (#393)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,7 @@ dependencies = [
  "rocket_codegen",
  "rocket_http",
  "serde",
+ "serde_json",
  "state",
  "tempfile",
  "time 0.3.44",

--- a/assets/web/static/checked-locations.css
+++ b/assets/web/static/checked-locations.css
@@ -1,0 +1,200 @@
+/**
+ * Checked Locations Display Styles
+ */
+
+/* Status bar at the top */
+.checked-locations-status {
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    padding: 8px 16px;
+    text-align: center;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.checked-locations-status .loading {
+    color: #aaa;
+    font-style: italic;
+}
+
+.checked-locations-status .checked-count {
+    color: #4caf50;
+    font-weight: bold;
+}
+
+.checked-locations-status .checked-separator {
+    color: #888;
+    margin: 0 4px;
+}
+
+.checked-locations-status .total-count {
+    color: #fff;
+}
+
+.checked-locations-status .checked-percent {
+    color: #888;
+    margin-left: 8px;
+}
+
+.checked-locations-status.error {
+    background: rgba(139, 0, 0, 0.7);
+}
+
+.checked-locations-status .error-text {
+    color: #ffcdd2;
+}
+
+/* Locations panel */
+.checked-locations-panel {
+    position: fixed;
+    right: 0;
+    top: 50px;
+    bottom: 60px;
+    width: 320px;
+    background: rgba(0, 0, 0, 0.9);
+    color: #fff;
+    border-left: 1px solid rgba(255, 255, 255, 0.2);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.3s ease;
+    z-index: 100;
+}
+
+.checked-locations-panel.collapsed {
+    transform: translateX(280px);
+}
+
+.checked-locations-panel .panel-toggle {
+    background: #333;
+    color: #fff;
+    border: none;
+    padding: 10px 16px;
+    cursor: pointer;
+    text-align: left;
+    font-size: 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.checked-locations-panel .panel-toggle:hover {
+    background: #444;
+}
+
+.checked-locations-panel .locations-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px;
+}
+
+.checked-locations-panel .location-group {
+    margin-bottom: 16px;
+}
+
+.checked-locations-panel .location-group h4 {
+    margin: 0 0 8px 0;
+    padding: 4px 8px;
+    background: #222;
+    border-radius: 4px;
+    font-size: 12px;
+    text-transform: uppercase;
+    color: #888;
+}
+
+.checked-locations-panel .location-group ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.checked-locations-panel .location-group li {
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 2px;
+}
+
+.checked-locations-panel .location-checked {
+    color: #4caf50;
+    text-decoration: line-through;
+    opacity: 0.7;
+}
+
+.checked-locations-panel .location-unchecked {
+    color: #fff;
+}
+
+/* Light theme overrides */
+@media (prefers-color-scheme: light) {
+    .checked-locations-status {
+        background: rgba(255, 255, 255, 0.95);
+        color: #333;
+        border-bottom: 1px solid #ddd;
+    }
+
+    .checked-locations-status .checked-count {
+        color: #2e7d32;
+    }
+
+    .checked-locations-status .checked-separator {
+        color: #999;
+    }
+
+    .checked-locations-status .total-count {
+        color: #333;
+    }
+
+    .checked-locations-status .checked-percent {
+        color: #666;
+    }
+
+    .checked-locations-status.error {
+        background: rgba(255, 235, 238, 0.95);
+    }
+
+    .checked-locations-status .error-text {
+        color: #c62828;
+    }
+
+    .checked-locations-panel {
+        background: rgba(255, 255, 255, 0.98);
+        color: #333;
+        border-left: 1px solid #ddd;
+    }
+
+    .checked-locations-panel .panel-toggle {
+        background: #f5f5f5;
+        color: #333;
+    }
+
+    .checked-locations-panel .panel-toggle:hover {
+        background: #e0e0e0;
+    }
+
+    .checked-locations-panel .location-group h4 {
+        background: #f0f0f0;
+        color: #666;
+    }
+
+    .checked-locations-panel .location-checked {
+        color: #2e7d32;
+    }
+
+    .checked-locations-panel .location-unchecked {
+        color: #333;
+    }
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+    .checked-locations-panel {
+        width: 100%;
+        top: auto;
+        bottom: 0;
+        height: 300px;
+        border-left: none;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .checked-locations-panel.collapsed {
+        transform: translateY(260px);
+    }
+}

--- a/assets/web/static/checked-locations.js
+++ b/assets/web/static/checked-locations.js
@@ -1,0 +1,244 @@
+/**
+ * Checked Locations Display Module
+ *
+ * This module fetches and displays the checked locations status
+ * from the API endpoint and updates the UI accordingly.
+ */
+
+// Checked locations state
+let checkedLocationsState = {
+    locations: {},
+    lastUpdate: null,
+    isLoading: false,
+    error: null
+};
+
+// Status display element
+let statusElement = null;
+
+/**
+ * Get the current room name from the URL
+ */
+function getRoomName() {
+    const match = window.location.pathname.match(/^\/room\/([0-9A-Za-z-]+)\/?$/);
+    return match ? match[1] : null;
+}
+
+/**
+ * Fetch checked locations from the API
+ */
+async function fetchCheckedLocations() {
+    const roomName = getRoomName();
+    if (!roomName) {
+        return null;
+    }
+
+    try {
+        checkedLocationsState.isLoading = true;
+        const response = await fetch(`/api/room/${encodeURIComponent(roomName)}/checked-locations`);
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        checkedLocationsState.locations = {};
+
+        // Build a map of location_id -> status
+        for (const loc of data.locations) {
+            checkedLocationsState.locations[loc.location_id] = loc.status;
+        }
+
+        checkedLocationsState.lastUpdate = new Date();
+        checkedLocationsState.error = null;
+        checkedLocationsState.isLoading = false;
+
+        return data;
+    } catch (error) {
+        checkedLocationsState.error = error.message;
+        checkedLocationsState.isLoading = false;
+        console.error('Failed to fetch checked locations:', error);
+        return null;
+    }
+}
+
+/**
+ * Update the status display
+ */
+function updateStatusDisplay(data) {
+    if (!statusElement) return;
+
+    if (data) {
+        const percent = data.total_mapped > 0
+            ? Math.round((data.checked_count / data.total_mapped) * 100)
+            : 0;
+        statusElement.innerHTML = `
+            <span class="checked-count">${data.checked_count}</span>
+            <span class="checked-separator">/</span>
+            <span class="total-count">${data.total_mapped}</span>
+            <span class="checked-percent">(${percent}%)</span>
+        `;
+        statusElement.classList.remove('error');
+    } else if (checkedLocationsState.error) {
+        statusElement.innerHTML = `<span class="error-text">Error: ${checkedLocationsState.error}</span>`;
+        statusElement.classList.add('error');
+    }
+}
+
+/**
+ * Create the status display element
+ */
+function createStatusElement() {
+    if (statusElement) return statusElement;
+
+    const container = document.createElement('div');
+    container.id = 'checked-locations-status';
+    container.className = 'checked-locations-status';
+    container.innerHTML = '<span class="loading">Loading...</span>';
+
+    // Insert after the tracker container or at the top of body
+    const tracker = document.querySelector('.items');
+    if (tracker) {
+        tracker.parentNode.insertBefore(container, tracker);
+    } else {
+        document.body.insertBefore(container, document.body.firstChild);
+    }
+
+    statusElement = container;
+    return container;
+}
+
+/**
+ * Create the checked locations panel
+ */
+function createCheckedLocationsPanel() {
+    const panel = document.createElement('div');
+    panel.id = 'checked-locations-panel';
+    panel.className = 'checked-locations-panel collapsed';
+
+    const toggle = document.createElement('button');
+    toggle.className = 'panel-toggle';
+    toggle.textContent = 'Checked Locations';
+    toggle.addEventListener('click', () => {
+        panel.classList.toggle('collapsed');
+        toggle.textContent = panel.classList.contains('collapsed')
+            ? 'Checked Locations'
+            : 'Hide Locations';
+    });
+
+    const list = document.createElement('div');
+    list.className = 'locations-list';
+    list.id = 'checked-locations-list';
+
+    panel.appendChild(toggle);
+    panel.appendChild(list);
+
+    // Insert before footer
+    const footer = document.querySelector('footer');
+    if (footer) {
+        footer.parentNode.insertBefore(panel, footer);
+    } else {
+        document.body.appendChild(panel);
+    }
+
+    return panel;
+}
+
+/**
+ * Update the locations list display
+ */
+function updateLocationsList(data) {
+    const list = document.getElementById('checked-locations-list');
+    if (!list || !data) return;
+
+    // Group locations by area (based on common prefix patterns)
+    const grouped = {
+        checked: [],
+        unchecked: [],
+        unknown: []
+    };
+
+    for (const loc of data.locations) {
+        if (loc.status === 'Checked') {
+            grouped.checked.push(loc.location_id);
+        } else if (loc.status === 'Unchecked') {
+            grouped.unchecked.push(loc.location_id);
+        } else {
+            grouped.unknown.push(loc.location_id);
+        }
+    }
+
+    let html = '';
+
+    if (grouped.checked.length > 0) {
+        html += '<div class="location-group"><h4>Checked</h4><ul>';
+        for (const loc of grouped.checked.sort()) {
+            html += `<li class="location-checked">${escapeHtml(loc)}</li>`;
+        }
+        html += '</ul></div>';
+    }
+
+    if (grouped.unchecked.length > 0) {
+        html += '<div class="location-group"><h4>Unchecked</h4><ul>';
+        for (const loc of grouped.unchecked.sort()) {
+            html += `<li class="location-unchecked">${escapeHtml(loc)}</li>`;
+        }
+        html += '</ul></div>';
+    }
+
+    list.innerHTML = html;
+}
+
+/**
+ * Escape HTML special characters
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Refresh checked locations and update display
+ */
+async function refreshCheckedLocations() {
+    const data = await fetchCheckedLocations();
+    updateStatusDisplay(data);
+    updateLocationsList(data);
+    return data;
+}
+
+/**
+ * Initialize the checked locations display
+ */
+function initCheckedLocations() {
+    const roomName = getRoomName();
+    if (!roomName) {
+        // Not on a room page, skip initialization
+        return;
+    }
+
+    // Create UI elements
+    createStatusElement();
+    createCheckedLocationsPanel();
+
+    // Initial fetch
+    refreshCheckedLocations();
+
+    // Set up periodic refresh (every 5 seconds)
+    setInterval(refreshCheckedLocations, 5000);
+}
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCheckedLocations);
+} else {
+    initCheckedLocations();
+}
+
+// Export for external use
+window.checkedLocations = {
+    refresh: refreshCheckedLocations,
+    getState: () => checkedLocationsState,
+    isLocationChecked: (locationId) => checkedLocationsState.locations[locationId] === 'Checked'
+};

--- a/crate/oottracker-web/Cargo.toml
+++ b/crate/oottracker-web/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3"
 iced_core = "0.5"
 itertools = "0.10"
 lazy-regex = "2"
-rocket = "0.5.0-rc.2"
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"

--- a/crate/oottracker-web/src/http.rs
+++ b/crate/oottracker-web/src/http.rs
@@ -3,6 +3,7 @@ use {
     itertools::Itertools as _,
     ootr_utils::{PyModules, Version},
     oottracker::{
+        flag_mapping::{get_checked_locations_summary, CheckedLocationsSummary},
         ui::{DoubleTrackerLayout, TrackerCellId, TrackerLayout},
         websocket::MwItem,
         ModelState,
@@ -13,6 +14,7 @@ use {
         fs::{relative, FileServer},
         http::uri::Origin,
         response::{content::RawHtml, status::NotFound, Redirect},
+        serde::json::Json,
         uri, FromForm, FromFormField, Rocket, State, UriDisplayQuery,
     },
     rocket_util::{html, Doctype, ToHtml},
@@ -76,6 +78,7 @@ fn tracker_page<'a>(
                 meta(name = "viewport", content = "width=device-width, initial-scale=1");
                 link(rel = "icon", sizes = "512x512", type = "image/png", href = "/static/img/favicon.png");
                 link(rel = "stylesheet", href = "/static/common.css");
+                link(rel = "stylesheet", href = "/static/checked-locations.css");
                 @match theme {
                     Some(Theme::Light) => link(rel = "stylesheet", href = "/static/light.css");
                     None => link(rel = "stylesheet", href = "/static/light.css", media = "(prefers-color-scheme: light)");
@@ -91,6 +94,7 @@ fn tracker_page<'a>(
                     a(href = "https://fenhl.net/disc") : "disclaimer / Impressum";
                 }
                 script(src = "/static/proto.js");
+                script(src = "/static/checked-locations.js");
             }
         }
     }
@@ -445,6 +449,36 @@ async fn click(
     Ok(Redirect::to(rocket::uri!(room(name, _))))
 }
 
+// ============================================================================
+// API Endpoints for Checked Locations
+// ============================================================================
+
+/// Returns the checked locations for a room as JSON.
+///
+/// This endpoint provides the status of all mapped locations based on the
+/// current game state (memory flags). It can be used by the web UI to display
+/// which locations have been checked off.
+///
+/// # Response
+///
+/// Returns a JSON object with:
+/// - `total_mapped`: Total number of mapped locations
+/// - `checked_count`: Number of locations that have been checked
+/// - `unchecked_count`: Number of locations not yet checked
+/// - `unknown_count`: Number of locations with unknown status
+/// - `locations`: Array of individual location check results
+#[rocket::get("/api/room/<name>/checked-locations")]
+async fn api_checked_locations(
+    rooms: &State<Rooms>,
+    name: &str,
+) -> Result<Json<CheckedLocationsSummary>, Error> {
+    let summary = get_room(rooms, name.to_owned(), |room| {
+        get_checked_locations_summary(&room.model)
+    })
+    .await?;
+    Ok(Json(summary))
+}
+
 pub(crate) fn rocket(
     pool: PgPool,
     rooms: Rooms,
@@ -482,6 +516,7 @@ pub(crate) fn rocket(
             restream_double_room_layout,
             room,
             click,
+            api_checked_locations,
         ],
     )
 }
@@ -531,6 +566,7 @@ mod tests {
                 restream_double_room_layout,
                 room,
                 click,
+                api_checked_locations,
             ],
         )
     }

--- a/crate/oottracker/src/flag_mapping.rs
+++ b/crate/oottracker/src/flag_mapping.rs
@@ -3659,6 +3659,250 @@ pub fn get_dungeon_mappings(
 }
 
 // ============================================================================
+// Location Check Status
+// ============================================================================
+
+use crate::ModelState;
+
+/// Status of a location check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum CheckStatus {
+    /// Location has been checked (item collected).
+    Checked,
+    /// Location has not been checked yet.
+    Unchecked,
+    /// Check status cannot be determined (unmapped or unknown).
+    Unknown,
+}
+
+/// Result of checking a location.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LocationCheckResult {
+    /// The location ID.
+    pub location_id: String,
+    /// Whether the location has been checked.
+    pub status: CheckStatus,
+    /// Whether this location has a valid flag mapping.
+    pub is_mapped: bool,
+}
+
+/// Checks if a specific location has been checked based on the current game state.
+///
+/// # Arguments
+///
+/// * `mapping` - The flag mapping for the location
+/// * `model` - The current model state containing game memory
+///
+/// # Returns
+///
+/// `CheckStatus::Checked` if the location flag is set,
+/// `CheckStatus::Unchecked` if the flag is not set,
+/// `CheckStatus::Unknown` if the location is unmapped or cannot be determined.
+#[must_use]
+pub fn check_location_status(mapping: &FlagMapping, model: &ModelState) -> CheckStatus {
+    // If the mapping is a stub (unmapped), we can't determine the status
+    if mapping.is_stub() {
+        return CheckStatus::Unknown;
+    }
+
+    let flag_type = match mapping.flag_type {
+        Some(ft) => ft,
+        None => return CheckStatus::Unknown,
+    };
+
+    let flag_bit = match mapping.flag_bit {
+        Some(fb) => fb,
+        None => return CheckStatus::Unknown,
+    };
+
+    match flag_type {
+        FlagType::Chest => {
+            if let Some(scene_id) = mapping.scene_id {
+                let scene_flags = model.ram.scene_flags();
+                let chests = scene_flags.get_chest_flags(scene_id);
+                if chests & flag_bit != 0 {
+                    CheckStatus::Checked
+                } else {
+                    CheckStatus::Unchecked
+                }
+            } else {
+                CheckStatus::Unknown
+            }
+        }
+        FlagType::Switch => {
+            if let Some(scene_id) = mapping.scene_id {
+                let scene_flags = model.ram.scene_flags();
+                let switches = scene_flags.get_switch_flags(scene_id);
+                if switches & flag_bit != 0 {
+                    CheckStatus::Checked
+                } else {
+                    CheckStatus::Unchecked
+                }
+            } else {
+                CheckStatus::Unknown
+            }
+        }
+        FlagType::RoomClear => {
+            if let Some(scene_id) = mapping.scene_id {
+                let scene_flags = model.ram.scene_flags();
+                let room_clear = scene_flags.get_room_clear_flags(scene_id);
+                if room_clear & flag_bit != 0 {
+                    CheckStatus::Checked
+                } else {
+                    CheckStatus::Unchecked
+                }
+            } else {
+                CheckStatus::Unknown
+            }
+        }
+        FlagType::Collectible => {
+            if let Some(scene_id) = mapping.scene_id {
+                let scene_flags = model.ram.scene_flags();
+                let collectible = scene_flags.get_collectible_flags(scene_id);
+                if collectible & flag_bit != 0 {
+                    CheckStatus::Checked
+                } else {
+                    CheckStatus::Unchecked
+                }
+            } else {
+                CheckStatus::Unknown
+            }
+        }
+        FlagType::GoldSkulltula => {
+            // Gold Skulltulas use a different storage mechanism
+            // Check the gold_skulltulas field in save data
+            let gs_flags = model.ram.save.gold_skulltulas.get_raw_flags();
+            if gs_flags & flag_bit != 0 {
+                CheckStatus::Checked
+            } else {
+                CheckStatus::Unchecked
+            }
+        }
+        FlagType::EventChkInf => {
+            let event_flags = model.ram.save.event_chk_inf.get_raw_flags();
+            if event_flags & flag_bit != 0 {
+                CheckStatus::Checked
+            } else {
+                CheckStatus::Unchecked
+            }
+        }
+        FlagType::ItemGetInf => {
+            let item_flags = model.ram.save.item_get_inf.get_raw_flags();
+            if item_flags & flag_bit != 0 {
+                CheckStatus::Checked
+            } else {
+                CheckStatus::Unchecked
+            }
+        }
+        FlagType::InfTable => {
+            let inf_flags = model.ram.save.inf_table.get_raw_flags();
+            if inf_flags & flag_bit != 0 {
+                CheckStatus::Checked
+            } else {
+                CheckStatus::Unchecked
+            }
+        }
+        // These flag types need special handling or are not yet implemented
+        FlagType::Shop
+        | FlagType::Scrub
+        | FlagType::GreatFairy
+        | FlagType::Boss
+        | FlagType::Song
+        | FlagType::Fishing
+        | FlagType::Cow
+        | FlagType::GossipStone => CheckStatus::Unknown,
+    }
+}
+
+/// Returns all checked locations for the current game state.
+///
+/// # Arguments
+///
+/// * `model` - The current model state containing game memory
+///
+/// # Returns
+///
+/// A vector of `LocationCheckResult` for all mapped locations.
+pub fn get_all_checked_locations(model: &ModelState) -> Vec<LocationCheckResult> {
+    get_mapped_locations()
+        .map(|mapping| LocationCheckResult {
+            location_id: mapping.location_id.to_string(),
+            status: check_location_status(mapping, model),
+            is_mapped: mapping.is_mapped(),
+        })
+        .collect()
+}
+
+/// Returns all checked locations as a HashMap for efficient lookup.
+///
+/// # Arguments
+///
+/// * `model` - The current model state containing game memory
+///
+/// # Returns
+///
+/// A HashMap mapping location_id to CheckStatus.
+pub fn get_checked_locations_map(model: &ModelState) -> HashMap<String, CheckStatus> {
+    get_mapped_locations()
+        .map(|mapping| {
+            (
+                mapping.location_id.to_string(),
+                check_location_status(mapping, model),
+            )
+        })
+        .collect()
+}
+
+/// Summary of checked locations.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CheckedLocationsSummary {
+    /// Total number of mapped locations.
+    pub total_mapped: usize,
+    /// Number of checked locations.
+    pub checked_count: usize,
+    /// Number of unchecked locations.
+    pub unchecked_count: usize,
+    /// Number of locations with unknown status.
+    pub unknown_count: usize,
+    /// List of location check results.
+    pub locations: Vec<LocationCheckResult>,
+}
+
+/// Returns a summary of checked locations for the current game state.
+///
+/// # Arguments
+///
+/// * `model` - The current model state containing game memory
+///
+/// # Returns
+///
+/// A `CheckedLocationsSummary` containing counts and individual location statuses.
+pub fn get_checked_locations_summary(model: &ModelState) -> CheckedLocationsSummary {
+    let locations = get_all_checked_locations(model);
+    let total_mapped = locations.len();
+    let checked_count = locations
+        .iter()
+        .filter(|l| l.status == CheckStatus::Checked)
+        .count();
+    let unchecked_count = locations
+        .iter()
+        .filter(|l| l.status == CheckStatus::Unchecked)
+        .count();
+    let unknown_count = locations
+        .iter()
+        .filter(|l| l.status == CheckStatus::Unknown)
+        .count();
+
+    CheckedLocationsSummary {
+        total_mapped,
+        checked_count,
+        unchecked_count,
+        unknown_count,
+        locations,
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 

--- a/crate/oottracker/src/info_tables.rs
+++ b/crate/oottracker/src/info_tables.rs
@@ -133,3 +133,66 @@ flags_list! {
         },
     }
 }
+
+// ============================================================================
+// Raw Flag Accessors
+// ============================================================================
+
+impl EventChkInf {
+    /// Returns the raw event flags as a u32 bitmap.
+    ///
+    /// This converts the struct back to raw bytes for flag checking.
+    #[must_use]
+    pub fn get_raw_flags(&self) -> u32 {
+        let bytes: Vec<u8> = Vec::from(self);
+        let mut result = 0u32;
+        for (i, byte) in bytes.iter().take(4).enumerate() {
+            result |= (*byte as u32) << (i * 8);
+        }
+        result
+    }
+
+    /// Returns the full raw bytes.
+    #[must_use]
+    pub fn get_raw_bytes(&self) -> Vec<u8> {
+        Vec::from(self)
+    }
+}
+
+impl ItemGetInf {
+    /// Returns the raw item flags as a u32 bitmap.
+    #[must_use]
+    pub fn get_raw_flags(&self) -> u32 {
+        let bytes: Vec<u8> = Vec::from(self);
+        let mut result = 0u32;
+        for (i, byte) in bytes.iter().take(4).enumerate() {
+            result |= (*byte as u32) << (i * 8);
+        }
+        result
+    }
+
+    /// Returns the full raw bytes.
+    #[must_use]
+    pub fn get_raw_bytes(&self) -> Vec<u8> {
+        Vec::from(self)
+    }
+}
+
+impl InfTable {
+    /// Returns the raw inf_table flags as a u32 bitmap.
+    #[must_use]
+    pub fn get_raw_flags(&self) -> u32 {
+        let bytes: Vec<u8> = Vec::from(self);
+        let mut result = 0u32;
+        for (i, byte) in bytes.iter().take(4).enumerate() {
+            result |= (*byte as u32) << (i * 8);
+        }
+        result
+    }
+
+    /// Returns the full raw bytes.
+    #[must_use]
+    pub fn get_raw_bytes(&self) -> Vec<u8> {
+        Vec::from(self)
+    }
+}

--- a/crate/oottracker/src/scene.rs
+++ b/crate/oottracker/src/scene.rs
@@ -506,3 +506,117 @@ impl fmt::Display for Scene {
         self.0.fmt(f)
     }
 }
+
+// ============================================================================
+// Raw Scene Flag Accessors
+// ============================================================================
+//
+// These methods provide raw flag access by scene ID for the flag_mapping module.
+
+impl SceneFlags {
+    /// Returns the chest flags for the specified scene ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `scene_id` - The scene ID (0-100)
+    ///
+    /// # Returns
+    ///
+    /// The chest flags as a u32, or 0 if the scene ID is invalid.
+    #[must_use]
+    pub fn get_chest_flags(&self, scene_id: u8) -> u32 {
+        self.get_flags_for_scene(scene_id, |flags| flags.0)
+    }
+
+    /// Returns the switch flags for the specified scene ID.
+    #[must_use]
+    pub fn get_switch_flags(&self, scene_id: u8) -> u32 {
+        self.get_flags_for_scene(scene_id, |flags| flags.1)
+    }
+
+    /// Returns the room clear flags for the specified scene ID.
+    #[must_use]
+    pub fn get_room_clear_flags(&self, scene_id: u8) -> u32 {
+        self.get_flags_for_scene(scene_id, |flags| flags.2)
+    }
+
+    /// Returns the collectible flags for the specified scene ID.
+    #[must_use]
+    pub fn get_collectible_flags(&self, scene_id: u8) -> u32 {
+        self.get_flags_for_scene(scene_id, |flags| flags.3)
+    }
+
+    /// Helper to get raw flags for a scene by converting to raw bytes.
+    ///
+    /// This converts the SceneFlags struct back to raw bytes and extracts
+    /// the flags at the appropriate offset for the given scene.
+    fn get_flags_for_scene<F, T>(&self, scene_id: u8, extractor: F) -> T
+    where
+        F: FnOnce((u32, u32, u32, u32)) -> T,
+        T: Default,
+    {
+        // Convert to raw bytes
+        let bytes: Vec<u8> = Vec::from(self);
+
+        // Each scene is 0x1c (28) bytes
+        let scene_start = (scene_id as usize) * 0x1c;
+
+        // Make sure we're within bounds
+        if scene_start + 0x10 > bytes.len() {
+            return T::default();
+        }
+
+        // Extract the four u32 flag values
+        let chests = u32::from_be_bytes([
+            bytes[scene_start],
+            bytes[scene_start + 1],
+            bytes[scene_start + 2],
+            bytes[scene_start + 3],
+        ]);
+        let switches = u32::from_be_bytes([
+            bytes[scene_start + 0x04],
+            bytes[scene_start + 0x05],
+            bytes[scene_start + 0x06],
+            bytes[scene_start + 0x07],
+        ]);
+        let room_clear = u32::from_be_bytes([
+            bytes[scene_start + 0x08],
+            bytes[scene_start + 0x09],
+            bytes[scene_start + 0x0a],
+            bytes[scene_start + 0x0b],
+        ]);
+        let collectible = u32::from_be_bytes([
+            bytes[scene_start + 0x0c],
+            bytes[scene_start + 0x0d],
+            bytes[scene_start + 0x0e],
+            bytes[scene_start + 0x0f],
+        ]);
+
+        extractor((chests, switches, room_clear, collectible))
+    }
+}
+
+impl GoldSkulltulas {
+    /// Returns the raw gold skulltula flags as a u32 bitmap.
+    ///
+    /// This converts the Gold Skulltula data into a format that can be checked
+    /// against flag_bit values from FlagMapping.
+    #[must_use]
+    pub fn get_raw_flags(&self) -> u32 {
+        // The GoldSkulltulas struct has individual scene fields.
+        // For checking, we need to convert to raw bytes first and then read as u32.
+        // The struct is stored as 0x18 bytes (24 bytes).
+        let bytes: Vec<u8> = Vec::from(self);
+        let mut result = 0u32;
+        for (i, byte) in bytes.iter().take(4).enumerate() {
+            result |= (*byte as u32) << (i * 8);
+        }
+        result
+    }
+
+    /// Returns the full raw bytes for Gold Skulltula flags.
+    #[must_use]
+    pub fn get_all_raw_bytes(&self) -> Vec<u8> {
+        Vec::from(self)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `/api/checked_locations` endpoint to serve checked location status as JSON
- Creates frontend JavaScript to fetch and display checked locations
- Adds CSS styling for checked location indicators in the tracker UI
- Implements flag_mapping support for location tracking
- Updates info_tables and scene modules for location data

## Changes
- `assets/web/static/checked-locations.css` - Styling for checked location display
- `assets/web/static/checked-locations.js` - Frontend fetch and render logic
- `crate/oottracker-web/src/http.rs` - API endpoint for checked locations
- `crate/oottracker/src/flag_mapping.rs` - Location flag mapping support
- `crate/oottracker/src/info_tables.rs` - Info table extensions
- `crate/oottracker/src/scene.rs` - Scene data support

## Test plan
- [x] cargo fmt and clippy pass
- [ ] Manual verification of checked locations display in web tracker

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)