### PR TITLE
Fix CI to test oottracker crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # Run tests for crates that don't need randomizer
       - name: Run tests
-        run: cargo test -p ootr -p oottracker-derive -p ootmm
+        run: |
+          cargo test -p ootr -p oottracker-derive -p ootmm
+          cargo test -p oottracker --lib
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Summary
- Fixes #434
- Added `cargo test -p oottracker --lib` to CI workflow
- This catches test failures that were previously missed

## Test plan
- [x] CI now tests oottracker crate
- [x] cargo fmt and clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)