### PR TITLE
ci: Add oottracker crate to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # Run tests for crates that don't need randomizer
       - name: Run tests
-        run: cargo test -p ootr -p oottracker-derive -p ootmm
+        run: |
+          cargo test -p ootr -p oottracker-derive -p ootmm
+          cargo test -p oottracker --lib
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Summary
- Add `cargo test -p oottracker --lib` to the CI test job
- The oottracker crate was not being tested in CI, which allowed broken tests to merge unnoticed
- Uses `--lib` flag to test library portion without integration tests that require fixtures

## Test plan
- [x] Verify CI workflow file syntax is valid
- [ ] CI should now run tests for oottracker crate

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)