### PR TITLE
fix(gui): prevent crash when changing settings before config loads

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -712,11 +712,10 @@ impl Application for State<ootr_static::Rando> {
                 }
             }
             Message::SetAutoUpdateCheck(enable) => {
-                self.config
-                    .as_mut()
-                    .expect("config not yet loaded")
-                    .auto_update_check = Some(enable);
-                return self.save_config();
+                if let Some(config) = self.config.as_mut() {
+                    config.auto_update_check = Some(enable);
+                    return self.save_config();
+                }
             }
             Message::SetConnection(connection) => self.connection = Some(connection),
             Message::SetConnectionKind(kind) => {
@@ -729,18 +728,16 @@ impl Application for State<ootr_static::Rando> {
                 }
             }
             Message::SetLayoutPreference(layout_preference) => {
-                self.config
-                    .as_mut()
-                    .expect("config not yet loaded")
-                    .layout_preference = layout_preference;
-                return self.save_config();
+                if let Some(config) = self.config.as_mut() {
+                    config.layout_preference = layout_preference;
+                    return self.save_config();
+                }
             }
             Message::SetMedOrder(med_order) => {
-                self.config
-                    .as_mut()
-                    .expect("config not yet loaded")
-                    .med_order = med_order;
-                return self.save_config();
+                if let Some(config) = self.config.as_mut() {
+                    config.med_order = med_order;
+                    return self.save_config();
+                }
             }
             Message::SetPasscode(new_passcode) => {
                 if let Some(MenuState {
@@ -775,11 +772,10 @@ impl Application for State<ootr_static::Rando> {
                 }
             }
             Message::SetWarpSongOrder(warp_song_order) => {
-                self.config
-                    .as_mut()
-                    .expect("config not yet loaded")
-                    .warp_song_order = warp_song_order;
-                return self.save_config();
+                if let Some(config) = self.config.as_mut() {
+                    config.warp_song_order = warp_song_order;
+                    return self.save_config();
+                }
             }
             Message::UpdateCheck => {
                 self.update_check = UpdateCheckState::Checking;


### PR DESCRIPTION
## Problem

The GUI would panic with `config not yet loaded` if the user interacted with settings before the async config loading completed. This was a race condition - the settings UI was rendered and interactive before the config was ready.

Affected message handlers:
- `SetAutoUpdateCheck`
- `SetLayoutPreference`
- `SetMedOrder`
- `SetWarpSongOrder`

## Solution

Changed all four handlers to use `if let Some(config) = self.config.as_mut()` instead of `.expect("config not yet loaded")`. If config isn't loaded yet, the operation is silently skipped. Once config loads (usually within ~1 second), settings work normally.

## Testing

1. Launch tracker
2. Immediately try to change layout preference before UI fully initializes
3. Should no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)