### PR TITLE
fix(gui): use TrackerLayout::Combo for combo layout preference

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -368,21 +368,7 @@ impl<R: Rando + 'static> State<R> {
                 }
             }
             LayoutPreference::Mm => TrackerLayout::MmDefault,
-            LayoutPreference::Combo => {
-                // For combo mode, use OoT layout for now
-                // TODO: Implement true combo layout that shows both OoT and MM items
-                if self
-                    .connection
-                    .as_ref()
-                    .is_none_or(|connection| connection.can_change_state())
-                {
-                    TrackerLayout::from(&self.config)
-                } else if let Some(ref config) = self.config {
-                    TrackerLayout::new_auto(config)
-                } else {
-                    TrackerLayout::default_auto()
-                }
-            }
+            LayoutPreference::Combo => TrackerLayout::Combo,
         }
     }
 

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -5884,6 +5884,8 @@ pub mod images {
     oottracker_derive::embed_images!("assets/img/extra-images-overlay");
     oottracker_derive::embed_images!("assets/img/extra-images-overlay-dimmed");
     oottracker_derive::embed_images!("assets/img/extra-overlays");
+    oottracker_derive::embed_images!("assets/img/mm-images");
+    oottracker_derive::embed_images!("assets/img/mm-images-dimmed");
     oottracker_derive::embed_images!("assets/img/xopar-images");
     oottracker_derive::embed_images!("assets/img/xopar-images-count");
     oottracker_derive::embed_images!("assets/img/xopar-images-dimmed");


### PR DESCRIPTION
## Problem

The combo layout was already fully implemented in `ui.rs` with both OoT and MM items (7 rows × 12 columns showing medallions, boss remains, transformation masks, songs, equipment from both games), but the GUI was ignoring it and using OoT layout instead.

## Solution

One-line fix: `LayoutPreference::Combo => TrackerLayout::Combo`

## Before
Combo layout preference → Shows OoT items only

## After  
Combo layout preference → Shows both OoT and MM items in unified grid

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)