### PR TITLE
fix(gui): Return TrackerLayout::Combo for Combo layout preference

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -386,21 +386,7 @@ impl<R: Rando + 'static> State<R> {
                 }
             }
             LayoutPreference::Mm => TrackerLayout::MmDefault,
-            LayoutPreference::Combo => {
-                // For combo mode, use OoT layout for now
-                // TODO: Implement true combo layout that shows both OoT and MM items
-                if self
-                    .connection
-                    .as_ref()
-                    .is_none_or(|connection| connection.can_change_state())
-                {
-                    TrackerLayout::from(&self.config)
-                } else if let Some(ref config) = self.config {
-                    TrackerLayout::new_auto(config)
-                } else {
-                    TrackerLayout::default_auto()
-                }
-            }
+            LayoutPreference::Combo => TrackerLayout::Combo,
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #461
- Removes the workaround that returned OoT layout for Combo mode
- Now correctly returns `TrackerLayout::Combo` which already has both OoT and MM cells defined

## Changes
- Simplified `LayoutPreference::Combo` match arm to directly return `TrackerLayout::Combo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)