### PR TITLE
feat(ui): Add dungeon item layouts to LayoutPreference

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -392,6 +392,9 @@ impl<R: Rando + 'static> State<R> {
             }
             LayoutPreference::Mm => TrackerLayout::MmDefault,
             LayoutPreference::Combo => TrackerLayout::Combo,
+            LayoutPreference::DungeonItems => TrackerLayout::DungeonItems,
+            LayoutPreference::MmDungeonItems => TrackerLayout::MmDungeonItems,
+            LayoutPreference::MmStrayFairies => TrackerLayout::MmStrayFairies,
         }
     }
 

--- a/crate/oottracker/src/firebase.rs
+++ b/crate/oottracker/src/firebase.rs
@@ -433,7 +433,12 @@ pub trait App: fmt::Debug + Send + Sync + 'static {
             | MagicLens
             | MedallionWithLocation(_)
             | StoneWithLocation(_)
-            | MmSmallKeys { .. } => {
+            | MmSmallKeys { .. }
+            | OotMap { .. }
+            | OotCompass { .. }
+            | MmBossKey { .. }
+            | MmMap { .. }
+            | MmCompass { .. } => {
                 return Err(Error::NotImplemented(
                     "cell type not supported for set_cell",
                 ))
@@ -1067,7 +1072,12 @@ fn render_cell(cell_kind: TrackerCellKind, state: &ModelState) -> Result<Json, E
         | MagicLens
         | MedallionWithLocation(_)
         | StoneWithLocation(_)
-        | MmSmallKeys { .. } => {
+        | MmSmallKeys { .. }
+        | OotMap { .. }
+        | OotCompass { .. }
+        | MmBossKey { .. }
+        | MmMap { .. }
+        | MmCompass { .. } => {
             return Err(Error::NotImplemented(
                 "cell type not supported for render_cell",
             ))

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -398,6 +398,12 @@ pub enum LayoutPreference {
     Mm,
     /// Combined OoT/MM tracker layout
     Combo,
+    /// OoT dungeon items (maps, compasses)
+    DungeonItems,
+    /// MM dungeon items (maps, compasses, keys)
+    MmDungeonItems,
+    /// MM stray fairy counters
+    MmStrayFairies,
 }
 
 impl fmt::Display for LayoutPreference {
@@ -406,6 +412,9 @@ impl fmt::Display for LayoutPreference {
             LayoutPreference::Oot => write!(f, "Ocarina of Time"),
             LayoutPreference::Mm => write!(f, "Majora's Mask"),
             LayoutPreference::Combo => write!(f, "Combo (OoT + MM)"),
+            LayoutPreference::DungeonItems => write!(f, "OoT Dungeon Items"),
+            LayoutPreference::MmDungeonItems => write!(f, "MM Dungeon Items"),
+            LayoutPreference::MmStrayFairies => write!(f, "MM Stray Fairies"),
         }
     }
 }
@@ -5541,6 +5550,18 @@ mod tests {
         assert_eq!(format!("{}", LayoutPreference::Oot), "Ocarina of Time");
         assert_eq!(format!("{}", LayoutPreference::Mm), "Majora's Mask");
         assert_eq!(format!("{}", LayoutPreference::Combo), "Combo (OoT + MM)");
+        assert_eq!(
+            format!("{}", LayoutPreference::DungeonItems),
+            "OoT Dungeon Items"
+        );
+        assert_eq!(
+            format!("{}", LayoutPreference::MmDungeonItems),
+            "MM Dungeon Items"
+        );
+        assert_eq!(
+            format!("{}", LayoutPreference::MmStrayFairies),
+            "MM Stray Fairies"
+        );
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary
- Fixes #464
- Adds dungeon-specific layouts to the GUI settings

## Changes
- Added `LayoutPreference::DungeonItems` for OoT dungeon items (maps, compasses)
- Added `LayoutPreference::MmDungeonItems` for MM dungeon items
- Added `LayoutPreference::MmStrayFairies` for MM stray fairy counters
- Updated `Display` impl with user-friendly names
- Added match arms in GUI to return corresponding `TrackerLayout` variants
- Updated firebase.rs to handle new cell types in set_cell/render_cell
- Added unit tests for Display impl

## Notes
Will need rebase after #484 merges (both touch LayoutPreference match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)