### PR TITLE
feat(gui): Add checked locations state management

### DIFF
--- a/crate/oottracker-gui/src/main.rs
+++ b/crate/oottracker-gui/src/main.rs
@@ -41,6 +41,7 @@ use {
     ootr::Rando,
     oottracker::{
         firebase,
+        flag_mapping::{get_checked_locations_summary, CheckedLocationsSummary},
         github::Repo,
         net::{self, Connection},
         proto::Packet,
@@ -191,6 +192,7 @@ impl TrackerLayoutExt for TrackerLayout {
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""), Clone(bound = ""))]
 enum Message<R: Rando> {
+    CheckedLocationsUpdated(CheckedLocationsSummary),
     ClientDisconnected,
     CloseMenu,
     ConfigError(ui::Error),
@@ -359,6 +361,9 @@ struct State<R: Rando + 'static> {
     dismiss_notification_button: button::State,
     menu_state: Option<MenuState>,
     audio_player: Option<audio::AudioPlayer>,
+    /// Summary of checked locations from flag mapping.
+    /// Updated whenever model state changes.
+    checked_locations: Option<CheckedLocationsSummary>,
 }
 
 impl<R: Rando + 'static> State<R> {
@@ -520,6 +525,7 @@ impl Default for State<ootr_static::Rando> {
             dismiss_notification_button: button::State::default(),
             menu_state: None,
             audio_player: audio::AudioPlayer::new(),
+            checked_locations: None,
         }
     }
 }
@@ -574,6 +580,9 @@ impl Application for State<ootr_static::Rando> {
         message: Message<ootr_static::Rando>,
     ) -> Command<Message<ootr_static::Rando>> {
         match message {
+            Message::CheckedLocationsUpdated(summary) => {
+                self.checked_locations = Some(summary);
+            }
             Message::ClientDisconnected => {
                 if self
                     .notification
@@ -721,6 +730,8 @@ impl Application for State<ootr_static::Rando> {
                         self.model.update_knowledge();
                     }
                 }
+                // Update checked locations summary after model changes
+                self.checked_locations = Some(get_checked_locations_summary(&self.model));
             }
             Message::ResetUpdateState => {
                 self.update_check = UpdateCheckState::Unknown(button::State::default())

--- a/crate/oottracker/src/firebase.rs
+++ b/crate/oottracker/src/firebase.rs
@@ -22,8 +22,7 @@ use {
     std::{
         any::TypeId,
         collections::{hash_map::DefaultHasher, BTreeMap},
-        env,
-        fmt,
+        env, fmt,
         hash::{Hash, Hasher},
         iter,
         pin::Pin,
@@ -44,8 +43,7 @@ static OLD_RESTREAM_API_KEY: Lazy<String> =
     Lazy::new(|| env::var("OLD_RESTREAM_API_KEY").unwrap_or_default());
 static RESTREAM_API_KEY: Lazy<String> =
     Lazy::new(|| env::var("RESTREAM_API_KEY").unwrap_or_default());
-static RSL_API_KEY: Lazy<String> =
-    Lazy::new(|| env::var("RSL_API_KEY").unwrap_or_default());
+static RSL_API_KEY: Lazy<String> = Lazy::new(|| env::var("RSL_API_KEY").unwrap_or_default());
 
 macro_rules! cells {
     ($($cell_name:literal: $id:ident),*$(,)?) => {


### PR DESCRIPTION
## Summary
- Fixes #481
- Adds foundation for check tracking in GUI (state only, no UI yet)

## Changes
- Added `checked_locations: Option<CheckedLocationsSummary>` field to State
- Added `Message::CheckedLocationsUpdated` variant
- State updates automatically when model changes via `get_checked_locations_summary()`

## Part of #472
This is the first step in adding location check tracking to GUI:
1. **#481 (this PR)**: State management ✅
2. #482: Collapsible panel widget (blocked by this)
3. #483: Toggle integration (blocked by #482)

🤖 Generated with [Claude Code](https://claude.com/claude-code)