### PR TITLE
Fix 500 error on key click in combo layout (#502)

### DIFF
--- a/crate/oottracker-web/src/http.rs
+++ b/crate/oottracker-web/src/http.rs
@@ -488,7 +488,11 @@ async fn click_with_layout(
         Ok(())
     })
     .await?;
-    Ok(Redirect::to(rocket::uri!(room_with_layout(name, layout, Option::<Theme>::None))))
+    Ok(Redirect::to(rocket::uri!(room_with_layout(
+        name,
+        layout,
+        Option::<Theme>::None
+    ))))
 }
 
 // ============================================================================

--- a/crate/oottracker/src/ui.rs
+++ b/crate/oottracker/src/ui.rs
@@ -1528,7 +1528,8 @@ impl TrackerCellKind {
                     toggle(&mut mm_save.dungeon_items);
                 }
             }
-            BigPoeTriforce | BossKey { .. } | SongCheck { .. } => unimplemented!(),
+            BossKey { toggle, .. } => toggle(&mut state.ram.save.dungeon_items),
+            BigPoeTriforce | SongCheck { .. } => unimplemented!(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes 500 error when clicking key cells in combo layout
- Fixes #502

## Test plan
- [ ] Navigate to /room/test/combo
- [ ] Click on key cells
- [ ] Verify no 500 error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)