### PR TITLE
feat(web): Integrate checked-locations with WebSocket updates

### DIFF
--- a/assets/web/static/checked-locations.js
+++ b/assets/web/static/checked-locations.js
@@ -4,6 +4,9 @@
  * This module fetches and displays the checked locations status
  * from the API endpoint and updates the UI accordingly.
  * Locations are grouped by region with collapsible sections.
+ *
+ * Updates are triggered via WebSocket events from proto.js rather than
+ * polling, providing immediate refresh when tracker state changes.
  */
 
 // Checked locations state
@@ -705,8 +708,12 @@ function initCheckedLocations() {
     // Initial fetch
     refreshCheckedLocations();
 
-    // Set up periodic refresh (every 5 seconds)
-    setInterval(refreshCheckedLocations, 5000);
+    // Listen for WebSocket state changes from proto.js instead of polling
+    // This provides immediate updates when the tracker state changes
+    window.addEventListener('trackerStateChanged', function(event) {
+        // Refresh checked locations when tracker state changes
+        refreshCheckedLocations();
+    });
 }
 
 // Initialize when DOM is ready

--- a/assets/web/static/proto.js
+++ b/assets/web/static/proto.js
@@ -742,11 +742,15 @@ function handleWebSocketMessage(event) {
             for (let cellID = 0; cellID < numCells; cellID++) {
                 offset = updateCell(cellID, data, offset, true); // isInitialLoad = true
             }
+            // Dispatch event to notify other modules (e.g., checked-locations.js) of state change
+            window.dispatchEvent(new CustomEvent('trackerStateChanged', { detail: { type: 'init' } }));
             break;
         case 3:
             // Update
             const cellID = view.getUint8(offset++);
             updateCell(cellID, data, offset, false); // isInitialLoad = false
+            // Dispatch event to notify other modules (e.g., checked-locations.js) of state change
+            window.dispatchEvent(new CustomEvent('trackerStateChanged', { detail: { type: 'update', cellID: cellID } }));
             break;
         default:
             throw 'unexpected ServerMessage variant';


### PR DESCRIPTION
## Summary

Replaces 5-second polling in checked-locations.js with WebSocket event-driven updates.

**Closes #506**

### Changes:
- **checked-locations.js**: Replace `setInterval(refreshCheckedLocations, 5000)` with event listener for `trackerStateChanged`
- **proto.js**: Dispatch `trackerStateChanged` custom event on WebSocket init and update messages

### Benefits:
- **Immediate updates**: Checked locations refresh instantly when tracker state changes
- **Reduced server load**: No more polling every 5 seconds
- **Better UX**: Users see location updates without delay

### Note:
This PR should be merged after #545 (WebSocket status indicator) since both modify proto.js. The changes in this PR need to be applied to the refactored `handleWebSocketMessage` function.

## Test plan

- [ ] Verify checked locations update immediately when items are collected
- [ ] Verify initial load still populates checked locations correctly
- [ ] Verify no more 5-second polling requests in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)