### PR TITLE
feat(ootmm): Add spawn region configuration for reachability analysis

### DIFF
--- a/crate/ootmm/src/lib.rs
+++ b/crate/ootmm/src/lib.rs
@@ -21,6 +21,7 @@ pub mod expr;
 pub mod item;
 pub mod items;
 pub mod rando;
+pub mod reachability;
 pub mod region;
 pub mod settings;
 pub mod world_database;
@@ -38,6 +39,9 @@ pub use embedded_data::{create_world_database, create_world_database_from};
 
 // Re-export rando types
 pub use rando::{OotmmRando, OotmmRandoError, OotmmRegionName};
+
+// Re-export reachability types
+pub use reachability::{spawn_region, MM_SPAWN, OOT_SPAWN};
 
 // Re-export settings types
 pub use settings::{

--- a/crate/ootmm/src/reachability.rs
+++ b/crate/ootmm/src/reachability.rs
@@ -1,0 +1,50 @@
+//! Region reachability analysis for determining accessible locations.
+
+use crate::region::Game;
+
+/// OoT spawn region - Link's House in Kokiri Forest
+pub const OOT_SPAWN: &str = "oot_links_house";
+
+/// MM spawn region - Clock Tower
+pub const MM_SPAWN: &str = "mm_clock_tower";
+
+/// Returns the spawn region ID for the given game.
+#[must_use]
+pub fn spawn_region(game: Game) -> &'static str {
+    match game {
+        Game::Oot => OOT_SPAWN,
+        Game::Mm => MM_SPAWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embedded_data::create_world_database;
+
+    #[test]
+    fn test_oot_spawn_exists() {
+        let db = create_world_database().expect("Failed to load world database");
+        assert!(
+            db.get_region(OOT_SPAWN).is_some(),
+            "OoT spawn region '{}' not found in world database",
+            OOT_SPAWN
+        );
+    }
+
+    #[test]
+    fn test_mm_spawn_exists() {
+        let db = create_world_database().expect("Failed to load world database");
+        assert!(
+            db.get_region(MM_SPAWN).is_some(),
+            "MM spawn region '{}' not found in world database",
+            MM_SPAWN
+        );
+    }
+
+    #[test]
+    fn test_spawn_region_helper() {
+        assert_eq!(spawn_region(Game::Oot), OOT_SPAWN);
+        assert_eq!(spawn_region(Game::Mm), MM_SPAWN);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `reachability` module with spawn region constants (`OOT_SPAWN`, `MM_SPAWN`)
- Provides `spawn_region(game: Game)` helper function
- Includes unit tests verifying spawn regions exist in WorldDatabase

This is the foundation for region reachability analysis (issue #572).

Closes #585

## Test plan
- [x] `cargo test -p ootmm reachability` - 3 tests pass
- [x] Rebased onto main

🤖 Generated with [Claude Code](https://claude.ai/code)