### PR TITLE
Fix MM tracking when in OoT world by using stability check

### DIFF
--- a/crate/oottracker/src/net.rs
+++ b/crate/oottracker/src/net.rs
@@ -348,7 +348,6 @@ impl ComboTransitionTracker {
     }
 
     /// Check if the current game state is considered stable
-    #[allow(dead_code)]
     fn is_stable(&self) -> bool {
         self.frames_stable >= TRANSITION_STABILITY_FRAMES && !self.in_transition
     }
@@ -665,8 +664,11 @@ async fn retroarch_read_ram_with_combo_transitions(
 
                 let mut ram = Ram::from_range_bufs(oot_ranges)?;
 
-                // Preserve the fresh OoT state for when we switch to MM
-                combo_tracker.preserve_oot_state(&ram.save);
+                // Only preserve OoT state when we're stable (not during transition)
+                // During transitions, the data may be inconsistent/garbage
+                if combo_tracker.is_stable() {
+                    combo_tracker.preserve_oot_state(&ram.save);
+                }
 
                 // Use preserved MM data if available (MM address is garbage when OoT is active)
                 if let Some(preserved_mm) = combo_tracker.get_preserved_mm_save() {
@@ -689,8 +691,11 @@ async fn retroarch_read_ram_with_combo_transitions(
 
                 let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
 
-                // Preserve the fresh MM state
-                combo_tracker.preserve_mm_state(&mm_save);
+                // Only preserve MM state when we're stable (not during transition)
+                // During transitions, the data may be inconsistent/garbage
+                if combo_tracker.is_stable() {
+                    combo_tracker.preserve_mm_state(&mm_save);
+                }
 
                 // Use preserved OoT state (the OoT save address is garbage when MM is active)
                 let ram = if let Some(preserved_oot) = combo_tracker.get_preserved_oot_save() {


### PR DESCRIPTION
## Summary
In OoTMM combo mode, the inactive game's save address contains garbage data. The ComboTransitionTracker was preserving state unconditionally, which could save garbage data during game transitions when the detection might be wrong.

This fix:
- Removes `#[allow(dead_code)]` from `is_stable()` method
- Only preserves OoT/MM state when `is_stable()` returns true
- Prevents garbage data from being saved during transitions

During transitions (when both context addresses might be zero or in flux), the detector falls back to last known state which could be wrong. By only preserving state when stable (after `TRANSITION_STABILITY_FRAMES` consecutive frames of the same active game), we avoid corrupting the preserved state with garbage data.

Fixes #606

## Test plan
- [ ] Verify MM items don't show garbage when in OoT world
- [ ] Verify OoT items don't show garbage when in MM world
- [ ] Verify state preserves correctly after stable transition
- [ ] Run `cargo test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)