### PR TITLE
fix: Use detected game type for MM save parsing in OoTMM combo mode

### DIFF
--- a/crate/oottracker/src/mm_save.rs
+++ b/crate/oottracker/src/mm_save.rs
@@ -127,6 +127,19 @@ impl MmRomType {
             _ => MmRomType::Vanilla,
         }
     }
+
+    /// Determine if this is a combo ROM type.
+    ///
+    /// When `is_combo` is true, returns `OoTMM`, otherwise returns `Vanilla`.
+    /// This is used when the game type is detected automatically rather than
+    /// relying on environment variables.
+    pub fn from_combo_flag(is_combo: bool) -> Self {
+        if is_combo {
+            MmRomType::OoTMM
+        } else {
+            MmRomType::Vanilla
+        }
+    }
 }
 
 /// Memory offsets within MM SaveContext - vanilla MM structure

--- a/crate/oottracker/src/net.rs
+++ b/crate/oottracker/src/net.rs
@@ -539,7 +539,8 @@ async fn retroarch_read_ram_with_detection(
                     .try_collect::<Vec<_>>()
                     .await?;
 
-            let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
+            // Standalone MM uses vanilla offsets (is_combo = false)
+            let mm_save = ram::decode_mm_range_bufs_with_type(mm_ranges, false)?;
 
             // For standalone MM, we still need to create a valid Ram struct
             // Read OoT ranges as well for the base structure (they may be zeroed/invalid)
@@ -579,7 +580,8 @@ async fn retroarch_read_ram_with_detection(
                     .try_collect::<Vec<_>>()
                     .await?;
 
-                let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
+                // OoTMM combo mode uses OoTMM offsets (is_combo = true)
+                let mm_save = ram::decode_mm_range_bufs_with_type(mm_ranges, true)?;
                 ram.mm_save = Some(mm_save);
             }
 
@@ -687,7 +689,8 @@ async fn retroarch_read_ram_with_combo_transitions(
                     .try_collect::<Vec<_>>()
                     .await?;
 
-                let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
+                // OoTMM combo mode uses OoTMM offsets (is_combo = true)
+                let mm_save = ram::decode_mm_range_bufs_with_type(mm_ranges, true)?;
 
                 // Preserve the fresh MM state
                 combo_tracker.preserve_mm_state(&mm_save);

--- a/crate/oottracker/src/ram.rs
+++ b/crate/oottracker/src/ram.rs
@@ -781,6 +781,38 @@ pub fn decode_mm_save_data(save_data: &[u8]) -> Result<MmSave, DecodeError> {
     MmSave::from_save_data_with_type(save_data, rom_type).map_err(DecodeError::from)
 }
 
+/// Decodes Majora's Mask save data from pre-extracted range buffers with explicit combo mode flag.
+///
+/// This function is similar to `decode_mm_range_bufs` but accepts an explicit `is_combo` flag
+/// instead of relying on the `OOTTRACKER_MM_ROM_TYPE` environment variable. This should be
+/// used when the game type has been detected automatically (e.g., via context address polling).
+///
+/// # Arguments
+/// * `ranges` - Iterator yielding memory range buffers (expects exactly one buffer of `MM_SIZE` bytes)
+/// * `is_combo` - If true, uses OoTMM save offsets; if false, uses vanilla MM offsets
+///
+/// # Returns
+/// * `Ok(MmSave)` - Successfully decoded MM save data
+/// * `Err(DecodeError)` - If the ranges are invalid or parsing fails
+pub fn decode_mm_range_bufs_with_type(
+    ranges: impl IntoIterator<Item = Vec<u8>>,
+    is_combo: bool,
+) -> Result<MmSave, DecodeError> {
+    let mut iter = ranges.into_iter();
+
+    // Get the first (and only) range - the SaveContext
+    let save_data = iter.next().ok_or(DecodeError::Ranges)?;
+
+    // Validate size
+    if save_data.len() != mm_save::MM_SIZE {
+        return Err(DecodeError::Size(save_data.len()));
+    }
+
+    // Parse the save data with the specified ROM type
+    let rom_type = MmRomType::from_combo_flag(is_combo);
+    MmSave::from_save_data_with_type(&save_data, rom_type).map_err(DecodeError::from)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
The fairy tracking was broken in MM mode because the MM save data was being parsed using vanilla MM offsets instead of OoTMM offsets.

**Root cause:** The code detected the game type as OoTMMCombo via context address polling, but when parsing MM save data, it relied on the `OOTTRACKER_MM_ROM_TYPE` environment variable instead of the detected game type.

**Changes:**
- Add `MmRomType::from_combo_flag()` to convert from detected game type
- Add `decode_mm_range_bufs_with_type()` that accepts is_combo flag
- Update all MM save parsing call sites to use the new function with appropriate combo flag

This ensures fairy data is read from the correct OoTMM offsets (0x00D2) when playing in MM mode in an OoTMM combo ROM, rather than the vanilla MM offsets (0x00D0).

Fixes #607

## Test plan
- [ ] Verify fairy counts display correctly in MM mode (OoTMM)
- [ ] Verify fairy counts still work in vanilla MM
- [ ] Run `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)