### PR TITLE
fix: Use OoTMM offsets automatically in combo mode for MM song tracking

### DIFF
--- a/crate/oottracker/src/mm_save.rs
+++ b/crate/oottracker/src/mm_save.rs
@@ -3915,6 +3915,115 @@ mod tests {
     }
 
     // ========================================================================
+    // OoTMM-specific Parsing Tests
+    // ========================================================================
+
+    #[test]
+    fn test_ootmm_no_songs_when_quest_items_zero() {
+        // Regression test for GitHub issue #604:
+        // In OoTMM combo mode, MM song tracking was showing Time and Order songs
+        // when the user had no songs, because vanilla offsets were being used
+        // instead of OoTMM offsets.
+        use ootmm_offsets::*;
+
+        let mut data = vec![0u8; MM_SIZE];
+
+        // Quest items at OoTMM offset should be zero
+        data[QUEST_ITEMS..QUEST_ITEMS + 4].copy_from_slice(&0u32.to_be_bytes());
+
+        let save = MmSave::from_save_data_ootmm(&data).unwrap();
+
+        // All song bits should be false
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_TIME));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_ORDER));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_AWAKENING));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_GORON));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_ZORA));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_EMPTINESS));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_HEALING));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_EPONA));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_SOARING));
+        assert!(!save.quest_items.contains(MmQuestItems::SONG_STORMS));
+    }
+
+    #[test]
+    fn test_ootmm_parse_all_songs_from_raw() {
+        use ootmm_offsets::*;
+
+        let mut data = vec![0u8; MM_SIZE];
+
+        // Set all song bits
+        let quest_bits: u32 = MmQuestItems::SONG_AWAKENING.bits()
+            | MmQuestItems::SONG_GORON.bits()
+            | MmQuestItems::SONG_ZORA.bits()
+            | MmQuestItems::SONG_EMPTINESS.bits()
+            | MmQuestItems::SONG_ORDER.bits()
+            | MmQuestItems::SONG_TIME.bits()
+            | MmQuestItems::SONG_HEALING.bits()
+            | MmQuestItems::SONG_EPONA.bits()
+            | MmQuestItems::SONG_SOARING.bits()
+            | MmQuestItems::SONG_STORMS.bits()
+            | MmQuestItems::SONG_LULLABY_INTRO.bits();
+
+        data[QUEST_ITEMS..QUEST_ITEMS + 4].copy_from_slice(&quest_bits.to_be_bytes());
+
+        let save = MmSave::from_save_data_ootmm(&data).unwrap();
+
+        assert!(save.quest_items.contains(MmQuestItems::SONG_AWAKENING));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_GORON));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_ZORA));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_EMPTINESS));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_ORDER));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_TIME));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_HEALING));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_EPONA));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_SOARING));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_STORMS));
+        assert!(save.quest_items.contains(MmQuestItems::SONG_LULLABY_INTRO));
+    }
+
+    #[test]
+    fn test_ootmm_offset_differs_from_vanilla() {
+        // Verify that OoTMM and vanilla use different offsets for quest items
+        use offsets::QUEST_ITEMS as VANILLA_QUEST_ITEMS;
+        use ootmm_offsets::QUEST_ITEMS as OOTMM_QUEST_ITEMS;
+
+        // OoTMM uses offset 0xBA, vanilla uses 0xA4
+        assert_ne!(OOTMM_QUEST_ITEMS, VANILLA_QUEST_ITEMS);
+        assert_eq!(OOTMM_QUEST_ITEMS, 0xBA);
+        assert_eq!(VANILLA_QUEST_ITEMS, 0xA4);
+    }
+
+    #[test]
+    fn test_ootmm_using_vanilla_offset_reads_wrong_data() {
+        // This test demonstrates the bug from GitHub issue #604:
+        // If we use vanilla offsets (0xA4) on OoTMM data where quest_items
+        // are at 0xBA, we read from the wrong location.
+        //
+        // In OoTMM, offset 0xA4 is in the ammo array. If the user has 20 Deku Sticks,
+        // the ammo data at that location could be misinterpreted as songs.
+
+        use ootmm_offsets::QUEST_ITEMS as OOTMM_QUEST_ITEMS;
+
+        let mut data = vec![0u8; MM_SIZE];
+
+        // Set a song at the correct OoTMM offset
+        let quest_bits: u32 = MmQuestItems::SONG_SOARING.bits();
+        data[OOTMM_QUEST_ITEMS..OOTMM_QUEST_ITEMS + 4].copy_from_slice(&quest_bits.to_be_bytes());
+
+        // Parse with OoTMM parser - should correctly detect Song of Soaring
+        let ootmm_save = MmSave::from_save_data_ootmm(&data).unwrap();
+        assert!(ootmm_save.quest_items.contains(MmQuestItems::SONG_SOARING));
+
+        // Parse with vanilla parser - should NOT detect Song of Soaring
+        // (because vanilla reads from 0xA4 which is zeroed)
+        let vanilla_save = MmSave::from_save_data(&data).unwrap();
+        assert!(!vanilla_save
+            .quest_items
+            .contains(MmQuestItems::SONG_SOARING));
+    }
+
+    // ========================================================================
     // Edge Cases and Error Handling Tests
     // ========================================================================
 

--- a/crate/oottracker/src/net.rs
+++ b/crate/oottracker/src/net.rs
@@ -3,7 +3,7 @@ use crate::firebase;
 use {
     crate::{
         game_detection::{ActiveGame, GameDetector, GameType, TransitionState},
-        mm_save::MmSave,
+        mm_save::{MmRomType, MmSave},
         proto::{self, Packet, TCP_PORT},
         ram::{self, Ram},
         save::Save,
@@ -579,7 +579,8 @@ async fn retroarch_read_ram_with_detection(
                     .try_collect::<Vec<_>>()
                     .await?;
 
-                let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
+                // In combo mode, always use OoTMM offsets (the structure is different from vanilla MM)
+                let mm_save = ram::decode_mm_range_bufs_with_type(mm_ranges, MmRomType::OoTMM)?;
                 ram.mm_save = Some(mm_save);
             }
 
@@ -687,7 +688,8 @@ async fn retroarch_read_ram_with_combo_transitions(
                     .try_collect::<Vec<_>>()
                     .await?;
 
-                let mm_save = ram::decode_mm_range_bufs(mm_ranges)?;
+                // In combo mode, always use OoTMM offsets (the structure is different from vanilla MM)
+                let mm_save = ram::decode_mm_range_bufs_with_type(mm_ranges, MmRomType::OoTMM)?;
 
                 // Preserve the fresh MM state
                 combo_tracker.preserve_mm_state(&mm_save);

--- a/crate/oottracker/src/ram.rs
+++ b/crate/oottracker/src/ram.rs
@@ -720,6 +720,27 @@ pub fn decode_mm_ranges(ram_data: &[u8]) -> Result<MmSave, DecodeError> {
 pub fn decode_mm_range_bufs(
     ranges: impl IntoIterator<Item = Vec<u8>>,
 ) -> Result<MmSave, DecodeError> {
+    let rom_type = MmRomType::from_env();
+    decode_mm_range_bufs_with_type(ranges, rom_type)
+}
+
+/// Decodes Majora's Mask save data from memory range buffers with an explicit ROM type.
+///
+/// This function allows specifying the ROM type directly instead of reading from
+/// the environment variable. This is useful when the game type has been detected
+/// automatically (e.g., in OoTMM combo mode).
+///
+/// # Arguments
+/// * `ranges` - Iterator yielding the memory range buffers (currently just one)
+/// * `rom_type` - The ROM type to use for parsing (Vanilla or OoTMM)
+///
+/// # Returns
+/// * `Ok(MmSave)` - Successfully decoded MM save data
+/// * `Err(DecodeError)` - If the ranges are invalid or parsing fails
+pub fn decode_mm_range_bufs_with_type(
+    ranges: impl IntoIterator<Item = Vec<u8>>,
+    rom_type: MmRomType,
+) -> Result<MmSave, DecodeError> {
     let mut iter = ranges.into_iter();
 
     // Get the first (and only) range - the SaveContext
@@ -731,7 +752,6 @@ pub fn decode_mm_range_bufs(
     }
 
     // Parse the save data
-    let rom_type = MmRomType::from_env();
     MmSave::from_save_data_with_type(&save_data, rom_type).map_err(DecodeError::from)
 }
 


### PR DESCRIPTION
## Summary
Fixes MM song tracking showing incorrect songs (Time and Order) when the user had no songs in OoTMM combo mode.

**Root cause:** When in OoTMM combo mode, the code was using vanilla MM offsets (QUEST_ITEMS at 0xA4) instead of OoTMM offsets (0xBA). This caused the tracker to read from the wrong memory location - specifically the ammo array - and interpret random data as song flags.

**Changes:**
- Add `decode_mm_range_bufs_with_type()` function that accepts explicit ROM type
- Update combo tracking code to use `MmRomType::OoTMM` automatically
- Add OoTMM-specific tests for song parsing
- Verify the offset difference between vanilla (0xA4) and OoTMM (0xBA)

The fix ensures that when the game detector identifies OoTMM combo mode, the MM save parser automatically uses the correct OoTMM structure offsets without requiring the `OOTTRACKER_MM_ROM_TYPE` environment variable.

Fixes #604

## Test plan
- [ ] Verify MM songs don't show incorrectly when user has no songs
- [ ] Verify MM songs display correctly when acquired
- [ ] Run `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)