### PR TITLE
feat: Add comprehensive tests for OoTMM settings (Phase 6)

### DIFF
--- a/crate/ootmm/src/config_parser.rs
+++ b/crate/ootmm/src/config_parser.rs
@@ -598,4 +598,490 @@ worldFlags:
         assert!(settings.junk_locations.contains("oot_chest_1"));
         assert!(settings.world_flags.shared_items);
     }
+
+    // === Additional Integration Tests ===
+
+    #[test]
+    fn test_parse_partial_config_with_defaults() {
+        // Only set a few fields, rest should use defaults
+        let yaml = r#"
+erMoon: true
+logicMode: glitched
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        // Set values
+        assert!(settings.er_moon);
+        assert_eq!(settings.logic_mode, LogicMode::Glitched);
+
+        // Default values
+        assert!(!settings.skip_zelda);
+        assert!(!settings.ageless_boots);
+        assert_eq!(settings.bottle_count, 4);
+        assert_eq!(settings.ganon_boss_key, GanonBossKeyMode::Vanilla);
+        assert!(settings.open_dungeons_oot.is_empty());
+        assert!(settings.starting_items.is_empty());
+    }
+
+    #[test]
+    fn test_parse_empty_collections() {
+        let yaml = r#"
+openDungeonsOot: []
+mqDungeons: []
+logicTricks: []
+startingItems: {}
+junkLocations: []
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        assert!(settings.open_dungeons_oot.is_empty());
+        assert!(settings.mq_dungeons.is_empty());
+        assert!(settings.logic_tricks.is_empty());
+        assert!(settings.starting_items.is_empty());
+        assert!(settings.junk_locations.is_empty());
+    }
+
+    #[test]
+    fn test_parse_single_item_collections() {
+        let yaml = r#"
+openDungeonsOot:
+  - DC
+mqDungeons:
+  - forest_temple
+logicTricks:
+  - ONE_TRICK
+startingItems:
+  SingleItem: 1
+junkLocations:
+  - single_location
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        assert_eq!(settings.open_dungeons_oot.len(), 1);
+        assert!(settings
+            .open_dungeons_oot
+            .contains(&OotDungeon::DodongosCavern));
+        assert_eq!(settings.mq_dungeons.len(), 1);
+        assert_eq!(settings.logic_tricks.len(), 1);
+        assert_eq!(settings.starting_items.len(), 1);
+        assert_eq!(settings.junk_locations.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_invalid_dungeon_value() {
+        let yaml = r#"
+openDungeonsOot:
+  - InvalidDungeon
+"#;
+        // Invalid dungeon values should cause an error
+        let result = RandomizerSettings::from_yaml_str(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_wrong_type_for_boolean() {
+        let yaml = r#"
+erMoon: "not a boolean"
+"#;
+        let result = RandomizerSettings::from_yaml_str(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_wrong_type_for_numeric() {
+        let yaml = r#"
+bottleCount: "three"
+"#;
+        let result = RandomizerSettings::from_yaml_str(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_negative_numeric() {
+        // YAML parser might accept negative values, but the field is u8
+        // Let's see how it's handled
+        let yaml = r#"
+bottleCount: -1
+"#;
+        let result = RandomizerSettings::from_yaml_str(yaml);
+        // This should fail because u8 cannot be negative
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_yaml_with_comments() {
+        let yaml = r#"
+# This is a comment
+erMoon: true  # inline comment
+# Another comment
+skipZelda: true
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert!(settings.er_moon);
+        assert!(settings.skip_zelda);
+    }
+
+    #[test]
+    fn test_parse_yaml_with_anchors_and_aliases() {
+        let yaml = r#"
+# Define an anchor
+commonSettings: &common
+  erMoon: true
+  skipZelda: true
+
+# Note: YAML anchors work at document level, so we just test basic parsing
+erMoon: true
+skipZelda: true
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert!(settings.er_moon);
+        assert!(settings.skip_zelda);
+    }
+
+    #[test]
+    fn test_parse_multiline_yaml() {
+        let yaml = r#"
+openDungeonsOot:
+  - DC
+  - BotW
+  - JJ
+openDungeonsMm:
+  - ST
+  - WF
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.open_dungeons_oot.len(), 3);
+        assert_eq!(settings.open_dungeons_mm.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_flow_style_yaml() {
+        let yaml = r#"
+openDungeonsOot: [DC, BotW, JJ]
+openDungeonsMm: [ST, WF]
+startingItems: {Sword: 1, Shield: 2}
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.open_dungeons_oot.len(), 3);
+        assert_eq!(settings.open_dungeons_mm.len(), 2);
+        assert_eq!(settings.starting_items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_mixed_case_sensitivity() {
+        // YAML keys are case-sensitive, so this should use defaults
+        // for incorrectly cased keys
+        let yaml = r#"
+ErMoon: true
+SKIPZELDA: true
+"#;
+        let result = RandomizerSettings::from_yaml_str(yaml);
+        // Unknown fields should be ignored by serde
+        // If they are not, this might error or use defaults
+        if let Ok(settings) = result {
+            // These won't be set because keys are wrong case
+            assert!(!settings.er_moon);
+            assert!(!settings.skip_zelda);
+        }
+    }
+
+    #[test]
+    fn test_parse_special_condition_partial() {
+        let yaml = r#"
+specialConditions:
+  bridge:
+    medallions: 6
+  lacs:
+    stones: 3
+    skulltulas: 100
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        let bridge = settings.special_conditions.get("bridge").unwrap();
+        assert_eq!(bridge.medallions, 6);
+        assert_eq!(bridge.stones, 0); // default
+        assert_eq!(bridge.remains, 0); // default
+
+        let lacs = settings.special_conditions.get("lacs").unwrap();
+        assert_eq!(lacs.stones, 3);
+        assert_eq!(lacs.skulltulas, 100);
+        assert_eq!(lacs.medallions, 0); // default
+    }
+
+    #[test]
+    fn test_parse_world_flags_partial() {
+        let yaml = r#"
+worldFlags:
+  mmEnabled: false
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        // mmEnabled was explicitly set
+        assert!(!settings.world_flags.mm_enabled);
+        // ootEnabled should default to true
+        assert!(settings.world_flags.oot_enabled);
+        // shared_items should default to false
+        assert!(!settings.world_flags.shared_items);
+    }
+
+    #[test]
+    fn test_config_file_new_and_settings_access() {
+        let mut settings = RandomizerSettings::default();
+        settings.er_moon = true;
+        settings.bottle_count = 3;
+
+        let config = OotmmConfigFile::new(settings);
+
+        // Test settings() accessor
+        assert!(config.settings().er_moon);
+        assert_eq!(config.settings().bottle_count, 3);
+
+        // Test into_settings()
+        let retrieved = config.into_settings();
+        assert!(retrieved.er_moon);
+        assert_eq!(retrieved.bottle_count, 3);
+    }
+
+    #[test]
+    fn test_yaml_to_yaml_roundtrip() {
+        let yaml = r#"
+erMoon: true
+skipZelda: true
+logicMode: glitched
+bottleCount: 2
+openDungeonsOot:
+  - DC
+  - BotW
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        let config: OotmmConfigFile = settings.into();
+
+        let yaml_output = config.to_yaml_string().unwrap();
+
+        // Parse the output again
+        let settings2 = RandomizerSettings::from_yaml_str(&yaml_output).unwrap();
+
+        assert!(settings2.er_moon);
+        assert!(settings2.skip_zelda);
+        assert_eq!(settings2.logic_mode, LogicMode::Glitched);
+        assert_eq!(settings2.bottle_count, 2);
+        assert!(settings2
+            .open_dungeons_oot
+            .contains(&OotDungeon::DodongosCavern));
+        assert!(settings2
+            .open_dungeons_oot
+            .contains(&OotDungeon::BottomOfTheWell));
+    }
+
+    #[test]
+    fn test_config_error_source() {
+        use std::error::Error;
+
+        let io_err = ConfigError::Io(io::Error::new(io::ErrorKind::NotFound, "file not found"));
+        assert!(io_err.source().is_some());
+
+        let yaml_err = ConfigError::from(
+            serde_yaml::from_str::<RandomizerSettings>("invalid: [").unwrap_err(),
+        );
+        assert!(yaml_err.source().is_some());
+    }
+
+    #[test]
+    fn test_parse_all_dungeon_rewards_shuffle_modes() {
+        use crate::settings::DungeonRewardShuffle;
+
+        for (yaml_val, expected) in [
+            ("vanilla", DungeonRewardShuffle::Vanilla),
+            ("dungeonBlueWarps", DungeonRewardShuffle::DungeonBlueWarps),
+            ("anywhere", DungeonRewardShuffle::Anywhere),
+        ] {
+            let yaml = format!("dungeonRewardShuffle: {}", yaml_val);
+            let settings = RandomizerSettings::from_yaml_str(&yaml).unwrap();
+            assert_eq!(settings.dungeon_reward_shuffle, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_all_rainbow_bridge_modes() {
+        use crate::settings::RainbowBridgeMode;
+
+        for (yaml_val, expected) in [
+            ("vanilla", RainbowBridgeMode::Vanilla),
+            ("open", RainbowBridgeMode::Open),
+            ("medallions", RainbowBridgeMode::Medallions),
+            ("stones", RainbowBridgeMode::Stones),
+            ("dungeonRewards", RainbowBridgeMode::DungeonRewards),
+            ("skulltulas", RainbowBridgeMode::Skulltulas),
+            ("remains", RainbowBridgeMode::Remains),
+            ("custom", RainbowBridgeMode::Custom),
+        ] {
+            let yaml = format!("rainbowBridge: {}", yaml_val);
+            let settings = RandomizerSettings::from_yaml_str(&yaml).unwrap();
+            assert_eq!(settings.rainbow_bridge, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_all_damage_multiplier_modes() {
+        use crate::settings::DamageMultiplier;
+
+        for (yaml_val, expected) in [
+            ("half", DamageMultiplier::Half),
+            ("normal", DamageMultiplier::Normal),
+            ("double", DamageMultiplier::Double),
+            ("quadruple", DamageMultiplier::Quadruple),
+            ("ohko", DamageMultiplier::Ohko),
+        ] {
+            let yaml = format!("damageMultiplier: {}", yaml_val);
+            let settings = RandomizerSettings::from_yaml_str(&yaml).unwrap();
+            assert_eq!(settings.damage_multiplier, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_all_item_pool_modes() {
+        use crate::settings::ItemPool;
+
+        for (yaml_val, expected) in [
+            ("plentiful", ItemPool::Plentiful),
+            ("normal", ItemPool::Normal),
+            ("scarce", ItemPool::Scarce),
+            ("minimal", ItemPool::Minimal),
+        ] {
+            let yaml = format!("itemPool: {}", yaml_val);
+            let settings = RandomizerSettings::from_yaml_str(&yaml).unwrap();
+            assert_eq!(settings.item_pool, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_all_traps_quantity_modes() {
+        use crate::settings::TrapsQuantity;
+
+        for (yaml_val, expected) in [
+            ("none", TrapsQuantity::None),
+            ("few", TrapsQuantity::Few),
+            ("normal", TrapsQuantity::Normal),
+            ("many", TrapsQuantity::Many),
+            ("onslaught", TrapsQuantity::Onslaught),
+        ] {
+            let yaml = format!("trapsQuantity: {}", yaml_val);
+            let settings = RandomizerSettings::from_yaml_str(&yaml).unwrap();
+            assert_eq!(settings.traps_quantity, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_all_mq_dungeons() {
+        let yaml = r#"
+mqDungeons:
+  - deku_tree
+  - dodongos_cavern
+  - jabu_jabu
+  - forest_temple
+  - fire_temple
+  - water_temple
+  - spirit_temple
+  - shadow_temple
+  - bottom_of_the_well
+  - ice_cavern
+  - gerudo_training_ground
+  - ganons_castle
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.mq_dungeons.len(), 12);
+        assert!(settings.mq_dungeons.contains(&MqDungeon::DekuTree));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::DodongosCavern));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::JabuJabu));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::ForestTemple));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::FireTemple));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::WaterTemple));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::SpiritTemple));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::ShadowTemple));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::BottomOfTheWell));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::IceCavern));
+        assert!(settings
+            .mq_dungeons
+            .contains(&MqDungeon::GerudoTrainingGround));
+        assert!(settings.mq_dungeons.contains(&MqDungeon::GanonsCastle));
+    }
+
+    #[test]
+    fn test_parse_large_starting_items() {
+        let yaml = r#"
+startingItems:
+  Bombs: 99
+  Arrows: 50
+  Rupees: 500
+  DekuNuts: 40
+  DekuSticks: 30
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.starting_items.get("Bombs"), Some(&99));
+        assert_eq!(settings.starting_items.get("Arrows"), Some(&50));
+        assert_eq!(settings.starting_items.get("Rupees"), Some(&500));
+    }
+
+    #[test]
+    fn test_parse_many_junk_locations() {
+        let yaml = r#"
+junkLocations:
+  - location_1
+  - location_2
+  - location_3
+  - location_4
+  - location_5
+  - location_6
+  - location_7
+  - location_8
+  - location_9
+  - location_10
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.junk_locations.len(), 10);
+    }
+
+    #[test]
+    fn test_parse_many_logic_tricks() {
+        let yaml = r#"
+logicTricks:
+  - OOT_LENS
+  - OOT_HOOKSHOT_JUMP
+  - OOT_BOMB_HOVER
+  - MM_GORON_ROLL
+  - MM_ZORA_JUMP
+  - OOT_ADULT_KOKIRI
+  - MM_DEKU_SKIP
+"#;
+        let settings = RandomizerSettings::from_yaml_str(yaml).unwrap();
+        assert_eq!(settings.logic_tricks.len(), 7);
+        assert!(settings.logic_tricks.contains("OOT_LENS"));
+        assert!(settings.logic_tricks.contains("MM_GORON_ROLL"));
+    }
+
+    #[test]
+    fn test_json_and_yaml_consistency() {
+        // Create settings via YAML
+        let yaml = r#"
+erMoon: true
+bottleCount: 2
+logicMode: glitched
+openDungeonsOot:
+  - DC
+"#;
+        let settings_yaml = RandomizerSettings::from_yaml_str(yaml).unwrap();
+
+        // Serialize to JSON and back
+        let json = serde_json::to_string(&settings_yaml).unwrap();
+        let settings_json: RandomizerSettings = serde_json::from_str(&json).unwrap();
+
+        // They should match
+        assert_eq!(settings_yaml.er_moon, settings_json.er_moon);
+        assert_eq!(settings_yaml.bottle_count, settings_json.bottle_count);
+        assert_eq!(settings_yaml.logic_mode, settings_json.logic_mode);
+        assert_eq!(
+            settings_yaml.open_dungeons_oot,
+            settings_json.open_dungeons_oot
+        );
+    }
 }

--- a/crate/ootmm/src/settings.rs
+++ b/crate/ootmm/src/settings.rs
@@ -3976,4 +3976,1762 @@ mod tests {
         assert!(MapCompassShuffle::Anywhere.is_shuffled());
         assert!(!MapCompassShuffle::Removed.is_shuffled());
     }
+
+    // === DekuTreeState Tests ===
+
+    #[test]
+    fn test_deku_tree_state_default() {
+        let state = DekuTreeState::default();
+        assert_eq!(state, DekuTreeState::Closed);
+    }
+
+    #[test]
+    fn test_deku_tree_state_as_str() {
+        assert_eq!(DekuTreeState::Closed.as_str(), "closed");
+        assert_eq!(DekuTreeState::Open.as_str(), "open");
+        assert_eq!(DekuTreeState::Vanilla.as_str(), "vanilla");
+    }
+
+    #[test]
+    fn test_deku_tree_state_parse() {
+        assert_eq!(DekuTreeState::parse("closed"), Some(DekuTreeState::Closed));
+        assert_eq!(DekuTreeState::parse("open"), Some(DekuTreeState::Open));
+        assert_eq!(
+            DekuTreeState::parse("vanilla"),
+            Some(DekuTreeState::Vanilla)
+        );
+        assert_eq!(DekuTreeState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_deku_tree_state_roundtrip() {
+        for state in [
+            DekuTreeState::Closed,
+            DekuTreeState::Open,
+            DekuTreeState::Vanilla,
+        ] {
+            let s = state.as_str();
+            assert_eq!(DekuTreeState::parse(s), Some(state));
+        }
+    }
+
+    #[test]
+    fn test_deku_tree_state_serde_roundtrip() {
+        let state = DekuTreeState::Open;
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: DekuTreeState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, state);
+    }
+
+    // === DoorOfTimeState Tests ===
+
+    #[test]
+    fn test_door_of_time_state_default() {
+        let state = DoorOfTimeState::default();
+        assert_eq!(state, DoorOfTimeState::Closed);
+    }
+
+    #[test]
+    fn test_door_of_time_state_as_str() {
+        assert_eq!(DoorOfTimeState::Closed.as_str(), "closed");
+        assert_eq!(DoorOfTimeState::Open.as_str(), "open");
+    }
+
+    #[test]
+    fn test_door_of_time_state_parse() {
+        assert_eq!(
+            DoorOfTimeState::parse("closed"),
+            Some(DoorOfTimeState::Closed)
+        );
+        assert_eq!(DoorOfTimeState::parse("open"), Some(DoorOfTimeState::Open));
+        assert_eq!(DoorOfTimeState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_door_of_time_state_serde_roundtrip() {
+        let state = DoorOfTimeState::Open;
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: DoorOfTimeState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, state);
+    }
+
+    // === KakarikoGateState Tests ===
+
+    #[test]
+    fn test_kakariko_gate_state_default() {
+        let state = KakarikoGateState::default();
+        assert_eq!(state, KakarikoGateState::Closed);
+    }
+
+    #[test]
+    fn test_kakariko_gate_state_as_str() {
+        assert_eq!(KakarikoGateState::Closed.as_str(), "closed");
+        assert_eq!(KakarikoGateState::Open.as_str(), "open");
+    }
+
+    #[test]
+    fn test_kakariko_gate_state_parse() {
+        assert_eq!(
+            KakarikoGateState::parse("closed"),
+            Some(KakarikoGateState::Closed)
+        );
+        assert_eq!(
+            KakarikoGateState::parse("open"),
+            Some(KakarikoGateState::Open)
+        );
+        assert_eq!(KakarikoGateState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_kakariko_gate_state_serde_roundtrip() {
+        let state = KakarikoGateState::Open;
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: KakarikoGateState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, state);
+    }
+
+    // === GanonBossKeyMode Tests ===
+
+    #[test]
+    fn test_ganon_boss_key_mode_default() {
+        let mode = GanonBossKeyMode::default();
+        assert_eq!(mode, GanonBossKeyMode::Vanilla);
+    }
+
+    #[test]
+    fn test_ganon_boss_key_mode_as_str() {
+        assert_eq!(GanonBossKeyMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(GanonBossKeyMode::Removed.as_str(), "removed");
+        assert_eq!(GanonBossKeyMode::Custom.as_str(), "custom");
+    }
+
+    #[test]
+    fn test_ganon_boss_key_mode_parse() {
+        assert_eq!(
+            GanonBossKeyMode::parse("vanilla"),
+            Some(GanonBossKeyMode::Vanilla)
+        );
+        assert_eq!(
+            GanonBossKeyMode::parse("removed"),
+            Some(GanonBossKeyMode::Removed)
+        );
+        assert_eq!(
+            GanonBossKeyMode::parse("custom"),
+            Some(GanonBossKeyMode::Custom)
+        );
+        assert_eq!(GanonBossKeyMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_ganon_boss_key_mode_serde_roundtrip() {
+        for mode in [
+            GanonBossKeyMode::Vanilla,
+            GanonBossKeyMode::Removed,
+            GanonBossKeyMode::Custom,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: GanonBossKeyMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === LacsMode Tests ===
+
+    #[test]
+    fn test_lacs_mode_default() {
+        let mode = LacsMode::default();
+        assert_eq!(mode, LacsMode::Vanilla);
+    }
+
+    #[test]
+    fn test_lacs_mode_as_str() {
+        assert_eq!(LacsMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(LacsMode::Custom.as_str(), "custom");
+    }
+
+    #[test]
+    fn test_lacs_mode_parse() {
+        assert_eq!(LacsMode::parse("vanilla"), Some(LacsMode::Vanilla));
+        assert_eq!(LacsMode::parse("custom"), Some(LacsMode::Custom));
+        assert_eq!(LacsMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_lacs_mode_serde_roundtrip() {
+        for mode in [LacsMode::Vanilla, LacsMode::Custom] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: LacsMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === MajoraChildMode Tests ===
+
+    #[test]
+    fn test_majora_child_mode_default() {
+        let mode = MajoraChildMode::default();
+        assert_eq!(mode, MajoraChildMode::Vanilla);
+    }
+
+    #[test]
+    fn test_majora_child_mode_as_str() {
+        assert_eq!(MajoraChildMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(MajoraChildMode::None.as_str(), "none");
+        assert_eq!(MajoraChildMode::Custom.as_str(), "custom");
+    }
+
+    #[test]
+    fn test_majora_child_mode_parse() {
+        assert_eq!(
+            MajoraChildMode::parse("vanilla"),
+            Some(MajoraChildMode::Vanilla)
+        );
+        assert_eq!(MajoraChildMode::parse("none"), Some(MajoraChildMode::None));
+        assert_eq!(
+            MajoraChildMode::parse("custom"),
+            Some(MajoraChildMode::Custom)
+        );
+        assert_eq!(MajoraChildMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_majora_child_mode_serde_roundtrip() {
+        for mode in [
+            MajoraChildMode::Vanilla,
+            MajoraChildMode::None,
+            MajoraChildMode::Custom,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: MajoraChildMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === MoonCrashMode Tests ===
+
+    #[test]
+    fn test_moon_crash_mode_default() {
+        let mode = MoonCrashMode::default();
+        assert_eq!(mode, MoonCrashMode::Vanilla);
+    }
+
+    #[test]
+    fn test_moon_crash_mode_as_str() {
+        assert_eq!(MoonCrashMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(MoonCrashMode::Cycle.as_str(), "cycle");
+    }
+
+    #[test]
+    fn test_moon_crash_mode_parse() {
+        assert_eq!(
+            MoonCrashMode::parse("vanilla"),
+            Some(MoonCrashMode::Vanilla)
+        );
+        assert_eq!(MoonCrashMode::parse("cycle"), Some(MoonCrashMode::Cycle));
+        assert_eq!(MoonCrashMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_moon_crash_mode_serde_roundtrip() {
+        for mode in [MoonCrashMode::Vanilla, MoonCrashMode::Cycle] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: MoonCrashMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === AgeChangeMode Tests ===
+
+    #[test]
+    fn test_age_change_mode_default() {
+        let mode = AgeChangeMode::default();
+        assert_eq!(mode, AgeChangeMode::TempleOfTime);
+    }
+
+    #[test]
+    fn test_age_change_mode_as_str() {
+        assert_eq!(AgeChangeMode::TempleOfTime.as_str(), "templeOfTime");
+        assert_eq!(AgeChangeMode::None.as_str(), "none");
+        assert_eq!(AgeChangeMode::Oot.as_str(), "oot");
+    }
+
+    #[test]
+    fn test_age_change_mode_parse() {
+        assert_eq!(
+            AgeChangeMode::parse("templeOfTime"),
+            Some(AgeChangeMode::TempleOfTime)
+        );
+        assert_eq!(AgeChangeMode::parse("none"), Some(AgeChangeMode::None));
+        assert_eq!(AgeChangeMode::parse("oot"), Some(AgeChangeMode::Oot));
+        assert_eq!(AgeChangeMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_age_change_mode_serde_roundtrip() {
+        for mode in [
+            AgeChangeMode::TempleOfTime,
+            AgeChangeMode::None,
+            AgeChangeMode::Oot,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: AgeChangeMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === ClimbMostSurfacesState Tests ===
+
+    #[test]
+    fn test_climb_most_surfaces_state_default() {
+        let state = ClimbMostSurfacesState::default();
+        assert_eq!(state, ClimbMostSurfacesState::On);
+    }
+
+    #[test]
+    fn test_climb_most_surfaces_state_as_str() {
+        assert_eq!(ClimbMostSurfacesState::On.as_str(), "on");
+        assert_eq!(ClimbMostSurfacesState::Off.as_str(), "off");
+    }
+
+    #[test]
+    fn test_climb_most_surfaces_state_parse() {
+        assert_eq!(
+            ClimbMostSurfacesState::parse("on"),
+            Some(ClimbMostSurfacesState::On)
+        );
+        assert_eq!(
+            ClimbMostSurfacesState::parse("off"),
+            Some(ClimbMostSurfacesState::Off)
+        );
+        assert_eq!(ClimbMostSurfacesState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_climb_most_surfaces_state_serde_roundtrip() {
+        for state in [ClimbMostSurfacesState::On, ClimbMostSurfacesState::Off] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: ClimbMostSurfacesState = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === HookshotAnywhereState Tests ===
+
+    #[test]
+    fn test_hookshot_anywhere_state_default() {
+        let state = HookshotAnywhereState::default();
+        assert_eq!(state, HookshotAnywhereState::On);
+    }
+
+    #[test]
+    fn test_hookshot_anywhere_state_as_str() {
+        assert_eq!(HookshotAnywhereState::On.as_str(), "on");
+        assert_eq!(HookshotAnywhereState::Off.as_str(), "off");
+    }
+
+    #[test]
+    fn test_hookshot_anywhere_state_parse() {
+        assert_eq!(
+            HookshotAnywhereState::parse("on"),
+            Some(HookshotAnywhereState::On)
+        );
+        assert_eq!(
+            HookshotAnywhereState::parse("off"),
+            Some(HookshotAnywhereState::Off)
+        );
+        assert_eq!(HookshotAnywhereState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_hookshot_anywhere_state_serde_roundtrip() {
+        for state in [HookshotAnywhereState::On, HookshotAnywhereState::Off] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: HookshotAnywhereState = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === BeneathWellState Tests ===
+
+    #[test]
+    fn test_beneath_well_state_default() {
+        let state = BeneathWellState::default();
+        assert_eq!(state, BeneathWellState::Vanilla);
+    }
+
+    #[test]
+    fn test_beneath_well_state_as_str() {
+        assert_eq!(BeneathWellState::Vanilla.as_str(), "vanilla");
+        assert_eq!(BeneathWellState::Open.as_str(), "open");
+    }
+
+    #[test]
+    fn test_beneath_well_state_parse() {
+        assert_eq!(
+            BeneathWellState::parse("vanilla"),
+            Some(BeneathWellState::Vanilla)
+        );
+        assert_eq!(
+            BeneathWellState::parse("open"),
+            Some(BeneathWellState::Open)
+        );
+        assert_eq!(BeneathWellState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_beneath_well_state_serde_roundtrip() {
+        for state in [BeneathWellState::Vanilla, BeneathWellState::Open] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: BeneathWellState = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === ErOverworldState Tests ===
+
+    #[test]
+    fn test_er_overworld_state_default() {
+        let state = ErOverworldState::default();
+        assert_eq!(state, ErOverworldState::None);
+    }
+
+    #[test]
+    fn test_er_overworld_state_as_str() {
+        assert_eq!(ErOverworldState::None.as_str(), "none");
+        assert_eq!(ErOverworldState::Full.as_str(), "full");
+    }
+
+    #[test]
+    fn test_er_overworld_state_parse() {
+        assert_eq!(
+            ErOverworldState::parse("none"),
+            Some(ErOverworldState::None)
+        );
+        assert_eq!(
+            ErOverworldState::parse("full"),
+            Some(ErOverworldState::Full)
+        );
+        assert_eq!(ErOverworldState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_er_overworld_state_serde_roundtrip() {
+        for state in [ErOverworldState::None, ErOverworldState::Full] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: ErOverworldState = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === ErGrottosState Tests ===
+
+    #[test]
+    fn test_er_grottos_state_default() {
+        let state = ErGrottosState::default();
+        assert_eq!(state, ErGrottosState::None);
+    }
+
+    #[test]
+    fn test_er_grottos_state_as_str() {
+        assert_eq!(ErGrottosState::None.as_str(), "none");
+        assert_eq!(ErGrottosState::Full.as_str(), "full");
+    }
+
+    #[test]
+    fn test_er_grottos_state_parse() {
+        assert_eq!(ErGrottosState::parse("none"), Some(ErGrottosState::None));
+        assert_eq!(ErGrottosState::parse("full"), Some(ErGrottosState::Full));
+        assert_eq!(ErGrottosState::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_er_grottos_state_serde_roundtrip() {
+        for state in [ErGrottosState::None, ErGrottosState::Full] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: ErGrottosState = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === BossWarpPadsMode Tests ===
+
+    #[test]
+    fn test_boss_warp_pads_mode_default() {
+        let mode = BossWarpPadsMode::default();
+        assert_eq!(mode, BossWarpPadsMode::Vanilla);
+    }
+
+    #[test]
+    fn test_boss_warp_pads_mode_as_str() {
+        assert_eq!(BossWarpPadsMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(BossWarpPadsMode::Remains.as_str(), "remains");
+    }
+
+    #[test]
+    fn test_boss_warp_pads_mode_parse() {
+        assert_eq!(
+            BossWarpPadsMode::parse("vanilla"),
+            Some(BossWarpPadsMode::Vanilla)
+        );
+        assert_eq!(
+            BossWarpPadsMode::parse("remains"),
+            Some(BossWarpPadsMode::Remains)
+        );
+        assert_eq!(BossWarpPadsMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_boss_warp_pads_mode_serde_roundtrip() {
+        for mode in [BossWarpPadsMode::Vanilla, BossWarpPadsMode::Remains] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: BossWarpPadsMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === ClearStateDungeonsMm Tests ===
+
+    #[test]
+    fn test_clear_state_dungeons_mm_as_str() {
+        assert_eq!(ClearStateDungeonsMm::Woodfall.as_str(), "WF");
+        assert_eq!(ClearStateDungeonsMm::Both.as_str(), "both");
+    }
+
+    #[test]
+    fn test_clear_state_dungeons_mm_parse() {
+        assert_eq!(
+            ClearStateDungeonsMm::parse("WF"),
+            Some(ClearStateDungeonsMm::Woodfall)
+        );
+        assert_eq!(
+            ClearStateDungeonsMm::parse("both"),
+            Some(ClearStateDungeonsMm::Both)
+        );
+        assert_eq!(ClearStateDungeonsMm::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_clear_state_dungeons_mm_serde_roundtrip() {
+        for state in [ClearStateDungeonsMm::Woodfall, ClearStateDungeonsMm::Both] {
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: ClearStateDungeonsMm = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, state);
+        }
+    }
+
+    // === JpLayout Tests ===
+
+    #[test]
+    fn test_jp_layout_as_str() {
+        assert_eq!(JpLayout::GreatBayCoast.as_str(), "GreatBayCoast");
+        assert_eq!(JpLayout::StoneTowerEntrance.as_str(), "ST");
+        assert_eq!(JpLayout::StoneTower.as_str(), "StoneTower");
+    }
+
+    #[test]
+    fn test_jp_layout_parse() {
+        assert_eq!(
+            JpLayout::parse("GreatBayCoast"),
+            Some(JpLayout::GreatBayCoast)
+        );
+        assert_eq!(JpLayout::parse("ST"), Some(JpLayout::StoneTowerEntrance));
+        assert_eq!(JpLayout::parse("StoneTower"), Some(JpLayout::StoneTower));
+        assert_eq!(JpLayout::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_jp_layout_serde_roundtrip() {
+        for layout in [
+            JpLayout::GreatBayCoast,
+            JpLayout::StoneTowerEntrance,
+            JpLayout::StoneTower,
+        ] {
+            let json = serde_json::to_string(&layout).unwrap();
+            let parsed: JpLayout = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, layout);
+        }
+    }
+
+    // === SmallKeyShuffleOot Tests ===
+
+    #[test]
+    fn test_small_key_shuffle_oot_default() {
+        let mode = SmallKeyShuffleOot::default();
+        assert_eq!(mode, SmallKeyShuffleOot::Vanilla);
+    }
+
+    #[test]
+    fn test_small_key_shuffle_oot_as_str() {
+        assert_eq!(SmallKeyShuffleOot::Vanilla.as_str(), "vanilla");
+        assert_eq!(SmallKeyShuffleOot::Dungeon.as_str(), "dungeon");
+        assert_eq!(SmallKeyShuffleOot::Anywhere.as_str(), "anywhere");
+    }
+
+    #[test]
+    fn test_small_key_shuffle_oot_parse() {
+        assert_eq!(
+            SmallKeyShuffleOot::parse("vanilla"),
+            Some(SmallKeyShuffleOot::Vanilla)
+        );
+        assert_eq!(
+            SmallKeyShuffleOot::parse("dungeon"),
+            Some(SmallKeyShuffleOot::Dungeon)
+        );
+        assert_eq!(
+            SmallKeyShuffleOot::parse("anywhere"),
+            Some(SmallKeyShuffleOot::Anywhere)
+        );
+        assert_eq!(SmallKeyShuffleOot::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_small_key_shuffle_oot_serde_roundtrip() {
+        for mode in [
+            SmallKeyShuffleOot::Vanilla,
+            SmallKeyShuffleOot::Dungeon,
+            SmallKeyShuffleOot::Anywhere,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: SmallKeyShuffleOot = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === ShufflePotsMm Tests ===
+
+    #[test]
+    fn test_shuffle_pots_mm_default() {
+        let mode = ShufflePotsMm::default();
+        assert_eq!(mode, ShufflePotsMm::None);
+    }
+
+    #[test]
+    fn test_shuffle_pots_mm_as_str() {
+        assert_eq!(ShufflePotsMm::None.as_str(), "none");
+        assert_eq!(ShufflePotsMm::All.as_str(), "all");
+    }
+
+    #[test]
+    fn test_shuffle_pots_mm_parse() {
+        assert_eq!(ShufflePotsMm::parse("none"), Some(ShufflePotsMm::None));
+        assert_eq!(ShufflePotsMm::parse("all"), Some(ShufflePotsMm::All));
+        assert_eq!(ShufflePotsMm::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_shuffle_pots_mm_serde_roundtrip() {
+        for mode in [ShufflePotsMm::None, ShufflePotsMm::All] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: ShufflePotsMm = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === LogicMode Tests ===
+
+    #[test]
+    fn test_logic_mode_default() {
+        let mode = LogicMode::default();
+        assert_eq!(mode, LogicMode::Glitchless);
+    }
+
+    #[test]
+    fn test_logic_mode_as_str() {
+        assert_eq!(LogicMode::Glitchless.as_str(), "glitchless");
+        assert_eq!(LogicMode::Glitched.as_str(), "glitched");
+        assert_eq!(LogicMode::NoLogic.as_str(), "noLogic");
+    }
+
+    #[test]
+    fn test_logic_mode_parse() {
+        assert_eq!(LogicMode::parse("glitchless"), Some(LogicMode::Glitchless));
+        assert_eq!(LogicMode::parse("glitched"), Some(LogicMode::Glitched));
+        assert_eq!(LogicMode::parse("noLogic"), Some(LogicMode::NoLogic));
+        assert_eq!(LogicMode::parse("no_logic"), Some(LogicMode::NoLogic));
+        assert_eq!(LogicMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_logic_mode_serde_roundtrip() {
+        for mode in [
+            LogicMode::Glitchless,
+            LogicMode::Glitched,
+            LogicMode::NoLogic,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: LogicMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === ShopShuffleMode Tests ===
+
+    #[test]
+    fn test_shop_shuffle_mode_default() {
+        let mode = ShopShuffleMode::default();
+        assert_eq!(mode, ShopShuffleMode::None);
+    }
+
+    #[test]
+    fn test_shop_shuffle_mode_as_str() {
+        assert_eq!(ShopShuffleMode::None.as_str(), "none");
+        assert_eq!(ShopShuffleMode::OwnShop.as_str(), "ownShop");
+        assert_eq!(ShopShuffleMode::All.as_str(), "all");
+    }
+
+    #[test]
+    fn test_shop_shuffle_mode_parse() {
+        assert_eq!(ShopShuffleMode::parse("none"), Some(ShopShuffleMode::None));
+        assert_eq!(
+            ShopShuffleMode::parse("ownShop"),
+            Some(ShopShuffleMode::OwnShop)
+        );
+        assert_eq!(ShopShuffleMode::parse("all"), Some(ShopShuffleMode::All));
+        assert_eq!(ShopShuffleMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_shop_shuffle_mode_serde_roundtrip() {
+        for mode in [
+            ShopShuffleMode::None,
+            ShopShuffleMode::OwnShop,
+            ShopShuffleMode::All,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: ShopShuffleMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === PriceMode Tests ===
+
+    #[test]
+    fn test_price_mode_default() {
+        let mode = PriceMode::default();
+        assert_eq!(mode, PriceMode::Vanilla);
+    }
+
+    #[test]
+    fn test_price_mode_as_str() {
+        assert_eq!(PriceMode::Vanilla.as_str(), "vanilla");
+        assert_eq!(PriceMode::Weighted.as_str(), "weighted");
+        assert_eq!(PriceMode::Random.as_str(), "random");
+        assert_eq!(PriceMode::Fixed.as_str(), "fixed");
+    }
+
+    #[test]
+    fn test_price_mode_parse() {
+        assert_eq!(PriceMode::parse("vanilla"), Some(PriceMode::Vanilla));
+        assert_eq!(PriceMode::parse("weighted"), Some(PriceMode::Weighted));
+        assert_eq!(PriceMode::parse("random"), Some(PriceMode::Random));
+        assert_eq!(PriceMode::parse("fixed"), Some(PriceMode::Fixed));
+        assert_eq!(PriceMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_price_mode_serde_roundtrip() {
+        for mode in [
+            PriceMode::Vanilla,
+            PriceMode::Weighted,
+            PriceMode::Random,
+            PriceMode::Fixed,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: PriceMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === TownFairyShuffle Tests ===
+
+    #[test]
+    fn test_town_fairy_shuffle_default() {
+        let mode = TownFairyShuffle::default();
+        assert_eq!(mode, TownFairyShuffle::Vanilla);
+    }
+
+    #[test]
+    fn test_town_fairy_shuffle_as_str() {
+        assert_eq!(TownFairyShuffle::Vanilla.as_str(), "vanilla");
+        assert_eq!(TownFairyShuffle::Anywhere.as_str(), "anywhere");
+    }
+
+    #[test]
+    fn test_town_fairy_shuffle_parse() {
+        assert_eq!(
+            TownFairyShuffle::parse("vanilla"),
+            Some(TownFairyShuffle::Vanilla)
+        );
+        assert_eq!(
+            TownFairyShuffle::parse("anywhere"),
+            Some(TownFairyShuffle::Anywhere)
+        );
+        assert_eq!(TownFairyShuffle::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_town_fairy_shuffle_serde_roundtrip() {
+        for mode in [TownFairyShuffle::Vanilla, TownFairyShuffle::Anywhere] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: TownFairyShuffle = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === StrayFairyShuffle Tests ===
+
+    #[test]
+    fn test_stray_fairy_shuffle_default() {
+        let mode = StrayFairyShuffle::default();
+        assert_eq!(mode, StrayFairyShuffle::Vanilla);
+    }
+
+    #[test]
+    fn test_stray_fairy_shuffle_as_str() {
+        assert_eq!(StrayFairyShuffle::Vanilla.as_str(), "vanilla");
+        assert_eq!(StrayFairyShuffle::Starting.as_str(), "starting");
+        assert_eq!(StrayFairyShuffle::Removed.as_str(), "removed");
+        assert_eq!(StrayFairyShuffle::OwnDungeon.as_str(), "ownDungeon");
+        assert_eq!(StrayFairyShuffle::Anywhere.as_str(), "anywhere");
+    }
+
+    #[test]
+    fn test_stray_fairy_shuffle_parse() {
+        assert_eq!(
+            StrayFairyShuffle::parse("vanilla"),
+            Some(StrayFairyShuffle::Vanilla)
+        );
+        assert_eq!(
+            StrayFairyShuffle::parse("starting"),
+            Some(StrayFairyShuffle::Starting)
+        );
+        assert_eq!(
+            StrayFairyShuffle::parse("removed"),
+            Some(StrayFairyShuffle::Removed)
+        );
+        assert_eq!(
+            StrayFairyShuffle::parse("ownDungeon"),
+            Some(StrayFairyShuffle::OwnDungeon)
+        );
+        assert_eq!(
+            StrayFairyShuffle::parse("anywhere"),
+            Some(StrayFairyShuffle::Anywhere)
+        );
+        assert_eq!(StrayFairyShuffle::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_stray_fairy_shuffle_serde_roundtrip() {
+        for mode in [
+            StrayFairyShuffle::Vanilla,
+            StrayFairyShuffle::Starting,
+            StrayFairyShuffle::Removed,
+            StrayFairyShuffle::OwnDungeon,
+            StrayFairyShuffle::Anywhere,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: StrayFairyShuffle = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === CrossWarpMode Tests ===
+
+    #[test]
+    fn test_cross_warp_mode_default() {
+        let mode = CrossWarpMode::default();
+        assert_eq!(mode, CrossWarpMode::None);
+    }
+
+    #[test]
+    fn test_cross_warp_mode_as_str() {
+        assert_eq!(CrossWarpMode::None.as_str(), "none");
+        assert_eq!(CrossWarpMode::ChildOnly.as_str(), "childOnly");
+        assert_eq!(CrossWarpMode::AdultOnly.as_str(), "adultOnly");
+        assert_eq!(CrossWarpMode::Full.as_str(), "full");
+    }
+
+    #[test]
+    fn test_cross_warp_mode_parse() {
+        assert_eq!(CrossWarpMode::parse("none"), Some(CrossWarpMode::None));
+        assert_eq!(
+            CrossWarpMode::parse("childOnly"),
+            Some(CrossWarpMode::ChildOnly)
+        );
+        assert_eq!(
+            CrossWarpMode::parse("adultOnly"),
+            Some(CrossWarpMode::AdultOnly)
+        );
+        assert_eq!(CrossWarpMode::parse("full"), Some(CrossWarpMode::Full));
+        assert_eq!(CrossWarpMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_cross_warp_mode_serde_roundtrip() {
+        for mode in [
+            CrossWarpMode::None,
+            CrossWarpMode::ChildOnly,
+            CrossWarpMode::AdultOnly,
+            CrossWarpMode::Full,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: CrossWarpMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === CsmcMode Tests ===
+
+    #[test]
+    fn test_csmc_mode_default() {
+        let mode = CsmcMode::default();
+        assert_eq!(mode, CsmcMode::Never);
+    }
+
+    #[test]
+    fn test_csmc_mode_as_str() {
+        assert_eq!(CsmcMode::Never.as_str(), "never");
+        assert_eq!(CsmcMode::Always.as_str(), "always");
+        assert_eq!(CsmcMode::Agony.as_str(), "agony");
+    }
+
+    #[test]
+    fn test_csmc_mode_parse() {
+        assert_eq!(CsmcMode::parse("never"), Some(CsmcMode::Never));
+        assert_eq!(CsmcMode::parse("always"), Some(CsmcMode::Always));
+        assert_eq!(CsmcMode::parse("agony"), Some(CsmcMode::Agony));
+        assert_eq!(CsmcMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_csmc_mode_serde_roundtrip() {
+        for mode in [CsmcMode::Never, CsmcMode::Always, CsmcMode::Agony] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: CsmcMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === BombchuBehavior Tests ===
+
+    #[test]
+    fn test_bombchu_behavior_default() {
+        let mode = BombchuBehavior::default();
+        assert_eq!(mode, BombchuBehavior::Normal);
+    }
+
+    #[test]
+    fn test_bombchu_behavior_as_str() {
+        assert_eq!(BombchuBehavior::Normal.as_str(), "normal");
+        assert_eq!(BombchuBehavior::BombsOrLogic.as_str(), "bombsOrLogic");
+        assert_eq!(BombchuBehavior::AsBombs.as_str(), "asBombs");
+    }
+
+    #[test]
+    fn test_bombchu_behavior_parse() {
+        assert_eq!(
+            BombchuBehavior::parse("normal"),
+            Some(BombchuBehavior::Normal)
+        );
+        assert_eq!(
+            BombchuBehavior::parse("bombsOrLogic"),
+            Some(BombchuBehavior::BombsOrLogic)
+        );
+        assert_eq!(
+            BombchuBehavior::parse("asBombs"),
+            Some(BombchuBehavior::AsBombs)
+        );
+        assert_eq!(BombchuBehavior::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_bombchu_behavior_serde_roundtrip() {
+        for mode in [
+            BombchuBehavior::Normal,
+            BombchuBehavior::BombsOrLogic,
+            BombchuBehavior::AsBombs,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: BombchuBehavior = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === AutoInvertMode Tests ===
+
+    #[test]
+    fn test_auto_invert_mode_default() {
+        let mode = AutoInvertMode::default();
+        assert_eq!(mode, AutoInvertMode::Off);
+    }
+
+    #[test]
+    fn test_auto_invert_mode_as_str() {
+        assert_eq!(AutoInvertMode::Off.as_str(), "off");
+        assert_eq!(AutoInvertMode::FirstPerson.as_str(), "firstPerson");
+        assert_eq!(AutoInvertMode::Always.as_str(), "always");
+    }
+
+    #[test]
+    fn test_auto_invert_mode_parse() {
+        assert_eq!(AutoInvertMode::parse("off"), Some(AutoInvertMode::Off));
+        assert_eq!(
+            AutoInvertMode::parse("firstPerson"),
+            Some(AutoInvertMode::FirstPerson)
+        );
+        assert_eq!(
+            AutoInvertMode::parse("always"),
+            Some(AutoInvertMode::Always)
+        );
+        assert_eq!(AutoInvertMode::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_auto_invert_mode_serde_roundtrip() {
+        for mode in [
+            AutoInvertMode::Off,
+            AutoInvertMode::FirstPerson,
+            AutoInvertMode::Always,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: AutoInvertMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    // === StartingAge Tests ===
+
+    #[test]
+    fn test_starting_age_default() {
+        let age = StartingAge::default();
+        assert_eq!(age, StartingAge::Child);
+    }
+
+    #[test]
+    fn test_starting_age_as_str() {
+        assert_eq!(StartingAge::Child.as_str(), "child");
+        assert_eq!(StartingAge::Adult.as_str(), "adult");
+        assert_eq!(StartingAge::Random.as_str(), "random");
+    }
+
+    #[test]
+    fn test_starting_age_parse() {
+        assert_eq!(StartingAge::parse("child"), Some(StartingAge::Child));
+        assert_eq!(StartingAge::parse("adult"), Some(StartingAge::Adult));
+        assert_eq!(StartingAge::parse("random"), Some(StartingAge::Random));
+        assert_eq!(StartingAge::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_starting_age_serde_roundtrip() {
+        for age in [StartingAge::Child, StartingAge::Adult, StartingAge::Random] {
+            let json = serde_json::to_string(&age).unwrap();
+            let parsed: StartingAge = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, age);
+        }
+    }
+
+    // === DamageMultiplier Tests ===
+
+    #[test]
+    fn test_damage_multiplier_default() {
+        let mult = DamageMultiplier::default();
+        assert_eq!(mult, DamageMultiplier::Normal);
+    }
+
+    #[test]
+    fn test_damage_multiplier_as_str() {
+        assert_eq!(DamageMultiplier::Half.as_str(), "half");
+        assert_eq!(DamageMultiplier::Normal.as_str(), "normal");
+        assert_eq!(DamageMultiplier::Double.as_str(), "double");
+        assert_eq!(DamageMultiplier::Quadruple.as_str(), "quadruple");
+        assert_eq!(DamageMultiplier::Ohko.as_str(), "ohko");
+    }
+
+    #[test]
+    fn test_damage_multiplier_parse() {
+        assert_eq!(
+            DamageMultiplier::parse("half"),
+            Some(DamageMultiplier::Half)
+        );
+        assert_eq!(
+            DamageMultiplier::parse("normal"),
+            Some(DamageMultiplier::Normal)
+        );
+        assert_eq!(
+            DamageMultiplier::parse("double"),
+            Some(DamageMultiplier::Double)
+        );
+        assert_eq!(
+            DamageMultiplier::parse("quadruple"),
+            Some(DamageMultiplier::Quadruple)
+        );
+        assert_eq!(
+            DamageMultiplier::parse("ohko"),
+            Some(DamageMultiplier::Ohko)
+        );
+        assert_eq!(DamageMultiplier::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_damage_multiplier_serde_roundtrip() {
+        for mult in [
+            DamageMultiplier::Half,
+            DamageMultiplier::Normal,
+            DamageMultiplier::Double,
+            DamageMultiplier::Quadruple,
+            DamageMultiplier::Ohko,
+        ] {
+            let json = serde_json::to_string(&mult).unwrap();
+            let parsed: DamageMultiplier = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mult);
+        }
+    }
+
+    // === ItemPool Tests ===
+
+    #[test]
+    fn test_item_pool_default() {
+        let pool = ItemPool::default();
+        assert_eq!(pool, ItemPool::Normal);
+    }
+
+    #[test]
+    fn test_item_pool_as_str() {
+        assert_eq!(ItemPool::Plentiful.as_str(), "plentiful");
+        assert_eq!(ItemPool::Normal.as_str(), "normal");
+        assert_eq!(ItemPool::Scarce.as_str(), "scarce");
+        assert_eq!(ItemPool::Minimal.as_str(), "minimal");
+    }
+
+    #[test]
+    fn test_item_pool_parse() {
+        assert_eq!(ItemPool::parse("plentiful"), Some(ItemPool::Plentiful));
+        assert_eq!(ItemPool::parse("normal"), Some(ItemPool::Normal));
+        assert_eq!(ItemPool::parse("scarce"), Some(ItemPool::Scarce));
+        assert_eq!(ItemPool::parse("minimal"), Some(ItemPool::Minimal));
+        assert_eq!(ItemPool::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_item_pool_serde_roundtrip() {
+        for pool in [
+            ItemPool::Plentiful,
+            ItemPool::Normal,
+            ItemPool::Scarce,
+            ItemPool::Minimal,
+        ] {
+            let json = serde_json::to_string(&pool).unwrap();
+            let parsed: ItemPool = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, pool);
+        }
+    }
+
+    // === TrapsQuantity Tests ===
+
+    #[test]
+    fn test_traps_quantity_default() {
+        let qty = TrapsQuantity::default();
+        assert_eq!(qty, TrapsQuantity::None);
+    }
+
+    #[test]
+    fn test_traps_quantity_as_str() {
+        assert_eq!(TrapsQuantity::None.as_str(), "none");
+        assert_eq!(TrapsQuantity::Few.as_str(), "few");
+        assert_eq!(TrapsQuantity::Normal.as_str(), "normal");
+        assert_eq!(TrapsQuantity::Many.as_str(), "many");
+        assert_eq!(TrapsQuantity::Onslaught.as_str(), "onslaught");
+    }
+
+    #[test]
+    fn test_traps_quantity_parse() {
+        assert_eq!(TrapsQuantity::parse("none"), Some(TrapsQuantity::None));
+        assert_eq!(TrapsQuantity::parse("few"), Some(TrapsQuantity::Few));
+        assert_eq!(TrapsQuantity::parse("normal"), Some(TrapsQuantity::Normal));
+        assert_eq!(TrapsQuantity::parse("many"), Some(TrapsQuantity::Many));
+        assert_eq!(
+            TrapsQuantity::parse("onslaught"),
+            Some(TrapsQuantity::Onslaught)
+        );
+        assert_eq!(TrapsQuantity::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_traps_quantity_serde_roundtrip() {
+        for qty in [
+            TrapsQuantity::None,
+            TrapsQuantity::Few,
+            TrapsQuantity::Normal,
+            TrapsQuantity::Many,
+            TrapsQuantity::Onslaught,
+        ] {
+            let json = serde_json::to_string(&qty).unwrap();
+            let parsed: TrapsQuantity = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, qty);
+        }
+    }
+
+    // === SpecialCondition Tests ===
+
+    #[test]
+    fn test_special_condition_default() {
+        let cond = SpecialCondition::default();
+        assert_eq!(cond.stones, 0);
+        assert_eq!(cond.medallions, 0);
+        assert_eq!(cond.dungeon_rewards, 0);
+        assert_eq!(cond.skulltulas, 0);
+        assert_eq!(cond.remains, 0);
+        assert!(!cond.has_requirements());
+    }
+
+    #[test]
+    fn test_special_condition_new() {
+        let cond = SpecialCondition::new();
+        assert!(!cond.has_requirements());
+    }
+
+    #[test]
+    fn test_special_condition_with_medallions() {
+        let cond = SpecialCondition::with_medallions(6);
+        assert_eq!(cond.medallions, 6);
+        assert_eq!(cond.stones, 0);
+        assert!(cond.has_requirements());
+    }
+
+    #[test]
+    fn test_special_condition_with_stones() {
+        let cond = SpecialCondition::with_stones(3);
+        assert_eq!(cond.stones, 3);
+        assert_eq!(cond.medallions, 0);
+        assert!(cond.has_requirements());
+    }
+
+    #[test]
+    fn test_special_condition_has_requirements() {
+        let mut cond = SpecialCondition::default();
+        assert!(!cond.has_requirements());
+
+        cond.stones = 1;
+        assert!(cond.has_requirements());
+
+        cond = SpecialCondition::default();
+        cond.medallions = 1;
+        assert!(cond.has_requirements());
+
+        cond = SpecialCondition::default();
+        cond.dungeon_rewards = 1;
+        assert!(cond.has_requirements());
+
+        cond = SpecialCondition::default();
+        cond.skulltulas = 1;
+        assert!(cond.has_requirements());
+
+        cond = SpecialCondition::default();
+        cond.remains = 1;
+        assert!(cond.has_requirements());
+    }
+
+    #[test]
+    fn test_special_condition_serde_json_roundtrip() {
+        let cond = SpecialCondition {
+            stones: 3,
+            medallions: 6,
+            dungeon_rewards: 9,
+            skulltulas: 50,
+            remains: 4,
+        };
+        let json = serde_json::to_string(&cond).unwrap();
+        let parsed: SpecialCondition = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.stones, 3);
+        assert_eq!(parsed.medallions, 6);
+        assert_eq!(parsed.dungeon_rewards, 9);
+        assert_eq!(parsed.skulltulas, 50);
+        assert_eq!(parsed.remains, 4);
+    }
+
+    #[test]
+    fn test_special_condition_serde_yaml_roundtrip() {
+        let cond = SpecialCondition {
+            stones: 3,
+            medallions: 6,
+            dungeon_rewards: 0,
+            skulltulas: 0,
+            remains: 4,
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        let parsed: SpecialCondition = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.stones, 3);
+        assert_eq!(parsed.medallions, 6);
+        assert_eq!(parsed.remains, 4);
+    }
+
+    #[test]
+    fn test_special_condition_partial_deserialization() {
+        // Test that missing fields default to 0
+        let json = r#"{"medallions": 6}"#;
+        let parsed: SpecialCondition = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.medallions, 6);
+        assert_eq!(parsed.stones, 0);
+        assert_eq!(parsed.dungeon_rewards, 0);
+    }
+
+    // === WorldFlags Tests ===
+
+    #[test]
+    fn test_world_flags_default() {
+        // Default trait derives default values (false for booleans)
+        let flags = WorldFlags::default();
+        assert!(!flags.oot_enabled);
+        assert!(!flags.mm_enabled);
+        assert!(!flags.shared_items);
+        assert!(!flags.shared_masks);
+    }
+
+    #[test]
+    fn test_world_flags_new() {
+        // new() uses Default, so also defaults to false
+        let flags = WorldFlags::new();
+        assert!(!flags.is_oot_enabled());
+        assert!(!flags.is_mm_enabled());
+    }
+
+    #[test]
+    fn test_world_flags_accessors() {
+        let mut flags = WorldFlags::default();
+        // Start with default values (false)
+        assert!(!flags.is_oot_enabled());
+        assert!(!flags.is_mm_enabled());
+
+        // Set to true and verify
+        flags.oot_enabled = true;
+        assert!(flags.is_oot_enabled());
+
+        flags.mm_enabled = true;
+        assert!(flags.is_mm_enabled());
+    }
+
+    #[test]
+    fn test_world_flags_serde_json_roundtrip() {
+        let flags = WorldFlags {
+            oot_enabled: true,
+            mm_enabled: false,
+            shared_items: true,
+            shared_masks: true,
+        };
+        let json = serde_json::to_string(&flags).unwrap();
+        let parsed: WorldFlags = serde_json::from_str(&json).unwrap();
+        assert!(parsed.oot_enabled);
+        assert!(!parsed.mm_enabled);
+        assert!(parsed.shared_items);
+        assert!(parsed.shared_masks);
+    }
+
+    #[test]
+    fn test_world_flags_serde_yaml_roundtrip() {
+        let flags = WorldFlags {
+            oot_enabled: false,
+            mm_enabled: true,
+            shared_items: false,
+            shared_masks: true,
+        };
+        let yaml = serde_yaml::to_string(&flags).unwrap();
+        let parsed: WorldFlags = serde_yaml::from_str(&yaml).unwrap();
+        assert!(!parsed.oot_enabled);
+        assert!(parsed.mm_enabled);
+        assert!(!parsed.shared_items);
+        assert!(parsed.shared_masks);
+    }
+
+    #[test]
+    fn test_world_flags_partial_deserialization() {
+        // Test that missing fields use default values
+        let json = r#"{"sharedItems": true}"#;
+        let parsed: WorldFlags = serde_json::from_str(json).unwrap();
+        assert!(parsed.oot_enabled); // defaults to true
+        assert!(parsed.mm_enabled); // defaults to true
+        assert!(parsed.shared_items);
+        assert!(!parsed.shared_masks); // defaults to false
+    }
+
+    // === Starting Items Tests ===
+
+    #[test]
+    fn test_starting_items_operations() {
+        let mut settings = RandomizerSettings::new();
+        assert_eq!(settings.starting_item_quantity("Sword"), 0);
+        assert!(!settings.has_starting_item("Sword"));
+
+        settings.set_starting_item("Sword", 1);
+        assert_eq!(settings.starting_item_quantity("Sword"), 1);
+        assert!(settings.has_starting_item("Sword"));
+
+        settings.set_starting_item("Bow", 3);
+        assert_eq!(settings.starting_item_quantity("Bow"), 3);
+        assert_eq!(settings.starting_items_count(), 2);
+
+        settings.remove_starting_item("Sword");
+        assert!(!settings.has_starting_item("Sword"));
+        assert_eq!(settings.starting_items_count(), 1);
+
+        // Setting to 0 removes the item
+        settings.set_starting_item("Bow", 0);
+        assert!(!settings.has_starting_item("Bow"));
+        assert_eq!(settings.starting_items_count(), 0);
+    }
+
+    #[test]
+    fn test_starting_items_iterator() {
+        let mut settings = RandomizerSettings::new();
+        settings.set_starting_item("Sword", 1);
+        settings.set_starting_item("Shield", 2);
+        settings.set_starting_item("Bow", 3);
+
+        let items: Vec<_> = settings.starting_items_iter().collect();
+        assert_eq!(items.len(), 3);
+    }
+
+    #[test]
+    fn test_starting_items_serde_roundtrip() {
+        let mut settings = RandomizerSettings::new();
+        settings.set_starting_item("Kokiri_Sword", 1);
+        settings.set_starting_item("Deku_Shield", 1);
+        settings.set_starting_item("Bombs", 20);
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: RandomizerSettings = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.starting_item_quantity("Kokiri_Sword"), 1);
+        assert_eq!(parsed.starting_item_quantity("Deku_Shield"), 1);
+        assert_eq!(parsed.starting_item_quantity("Bombs"), 20);
+    }
+
+    // === Junk Locations Tests ===
+
+    #[test]
+    fn test_junk_locations_operations() {
+        let mut settings = RandomizerSettings::new();
+        assert!(!settings.is_junk_location("oot_chest_1"));
+        assert_eq!(settings.junk_locations_count(), 0);
+
+        settings.add_junk_location("oot_chest_1");
+        assert!(settings.is_junk_location("oot_chest_1"));
+        assert_eq!(settings.junk_locations_count(), 1);
+
+        settings.add_junk_location("mm_chest_2");
+        assert_eq!(settings.junk_locations_count(), 2);
+
+        settings.remove_junk_location("oot_chest_1");
+        assert!(!settings.is_junk_location("oot_chest_1"));
+        assert_eq!(settings.junk_locations_count(), 1);
+    }
+
+    #[test]
+    fn test_junk_locations_iterator() {
+        let mut settings = RandomizerSettings::new();
+        settings.add_junk_location("loc1");
+        settings.add_junk_location("loc2");
+        settings.add_junk_location("loc3");
+
+        let locations: Vec<_> = settings.junk_locations_iter().collect();
+        assert_eq!(locations.len(), 3);
+    }
+
+    #[test]
+    fn test_junk_locations_serde_roundtrip() {
+        let mut settings = RandomizerSettings::new();
+        settings.add_junk_location("oot_kokiri_chest");
+        settings.add_junk_location("mm_clock_tower_chest");
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: RandomizerSettings = serde_json::from_str(&json).unwrap();
+
+        assert!(parsed.is_junk_location("oot_kokiri_chest"));
+        assert!(parsed.is_junk_location("mm_clock_tower_chest"));
+    }
+
+    // === Special Condition Settings Methods Tests ===
+
+    #[test]
+    fn test_special_conditions_operations() {
+        let mut settings = RandomizerSettings::new();
+        assert!(!settings.has_special_condition("bridge"));
+        assert!(settings.get_special_condition("bridge").is_none());
+        assert!(settings.bridge_condition().is_none());
+        assert_eq!(settings.special_conditions_count(), 0);
+
+        let bridge_cond = SpecialCondition::with_medallions(6);
+        settings.set_special_condition("bridge", bridge_cond);
+
+        assert!(settings.has_special_condition("bridge"));
+        assert!(settings.get_special_condition("bridge").is_some());
+        assert!(settings.bridge_condition().is_some());
+        assert_eq!(settings.bridge_condition().unwrap().medallions, 6);
+        assert_eq!(settings.special_conditions_count(), 1);
+
+        settings.remove_special_condition("bridge");
+        assert!(!settings.has_special_condition("bridge"));
+        assert_eq!(settings.special_conditions_count(), 0);
+    }
+
+    #[test]
+    fn test_special_conditions_iterator() {
+        let mut settings = RandomizerSettings::new();
+        settings.set_special_condition("bridge", SpecialCondition::with_medallions(6));
+        settings.set_special_condition("lacs", SpecialCondition::with_stones(3));
+
+        let conditions: Vec<_> = settings.special_conditions_iter().collect();
+        assert_eq!(conditions.len(), 2);
+    }
+
+    #[test]
+    fn test_special_conditions_serde_roundtrip() {
+        let mut settings = RandomizerSettings::new();
+        settings.set_special_condition("bridge", SpecialCondition::with_medallions(6));
+        settings.set_special_condition("lacs", SpecialCondition::with_stones(3));
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: RandomizerSettings = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            parsed.get_special_condition("bridge").unwrap().medallions,
+            6
+        );
+        assert_eq!(parsed.get_special_condition("lacs").unwrap().stones, 3);
+    }
+
+    // === World Flags Settings Methods Tests ===
+
+    #[test]
+    fn test_world_flags_settings_accessors() {
+        let mut settings = RandomizerSettings::new();
+
+        // Default values (false for all booleans)
+        assert!(!settings.is_oot_enabled());
+        assert!(!settings.is_mm_enabled());
+        assert!(!settings.world_shared_items());
+        assert!(!settings.world_shared_masks());
+
+        // Modify and check
+        settings.world_flags.oot_enabled = true;
+        assert!(settings.is_oot_enabled());
+
+        settings.world_flags.mm_enabled = true;
+        assert!(settings.is_mm_enabled());
+
+        settings.world_flags.shared_items = true;
+        assert!(settings.world_shared_items());
+
+        settings.world_flags.shared_masks = true;
+        assert!(settings.world_shared_masks());
+    }
+
+    // === Comprehensive JSON Roundtrip Test ===
+
+    #[test]
+    fn test_comprehensive_json_roundtrip() {
+        let mut settings = RandomizerSettings::new();
+
+        // Set various boolean settings
+        settings.er_moon = true;
+        settings.skip_zelda = true;
+        settings.ageless_boots = true;
+        settings.shared_bows = true;
+
+        // Set enum settings
+        settings.ganon_boss_key = GanonBossKeyMode::Custom;
+        settings.logic_mode = LogicMode::Glitched;
+        settings.rainbow_bridge = RainbowBridgeMode::Medallions;
+        settings.starting_age = StartingAge::Adult;
+        settings.damage_multiplier = DamageMultiplier::Double;
+
+        // Set collection fields
+        settings
+            .open_dungeons_oot
+            .insert(OotDungeon::DodongosCavern);
+        settings.open_dungeons_mm.insert(MmDungeon::StoneTower);
+        settings.set_dungeon_mq(MqDungeon::ForestTemple);
+        settings.enable_trick("OOT_LENS");
+
+        // Set complex types
+        settings.set_starting_item("Sword", 1);
+        settings.add_junk_location("oot_chest");
+        settings.set_special_condition("bridge", SpecialCondition::with_medallions(6));
+
+        // Set world flags
+        settings.world_flags.shared_items = true;
+
+        // Serialize and deserialize
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: RandomizerSettings = serde_json::from_str(&json).unwrap();
+
+        // Verify all fields
+        assert!(parsed.er_moon);
+        assert!(parsed.skip_zelda);
+        assert!(parsed.ageless_boots);
+        assert!(parsed.shared_bows);
+        assert_eq!(parsed.ganon_boss_key, GanonBossKeyMode::Custom);
+        assert_eq!(parsed.logic_mode, LogicMode::Glitched);
+        assert_eq!(parsed.rainbow_bridge, RainbowBridgeMode::Medallions);
+        assert_eq!(parsed.starting_age, StartingAge::Adult);
+        assert_eq!(parsed.damage_multiplier, DamageMultiplier::Double);
+        assert!(parsed
+            .open_dungeons_oot
+            .contains(&OotDungeon::DodongosCavern));
+        assert!(parsed.open_dungeons_mm.contains(&MmDungeon::StoneTower));
+        assert!(parsed.is_dungeon_mq(MqDungeon::ForestTemple));
+        assert!(parsed.has_trick("OOT_LENS"));
+        assert_eq!(parsed.starting_item_quantity("Sword"), 1);
+        assert!(parsed.is_junk_location("oot_chest"));
+        assert_eq!(parsed.bridge_condition().unwrap().medallions, 6);
+        assert!(parsed.world_shared_items());
+    }
+
+    // === Comprehensive YAML Roundtrip Test ===
+
+    #[test]
+    fn test_comprehensive_yaml_roundtrip() {
+        let mut settings = RandomizerSettings::new();
+
+        // Set various settings
+        settings.er_moon = true;
+        settings.open_mask_shop = true;
+        settings.deku_tree = DekuTreeState::Open;
+        settings.door_of_time = DoorOfTimeState::Open;
+        settings.kakariko_gate = KakarikoGateState::Open;
+        settings.boss_warp_pads = BossWarpPadsMode::Remains;
+        settings.csmc = CsmcMode::Always;
+        settings.item_pool = ItemPool::Scarce;
+        settings.traps_quantity = TrapsQuantity::Many;
+
+        settings.open_dungeons_oot.insert(OotDungeon::Shadow);
+        settings.open_dungeons_oot.insert(OotDungeon::Water);
+        settings.jp_layouts.insert(JpLayout::StoneTower);
+
+        settings.set_starting_item("Bow", 1);
+        settings.set_starting_item("Bombs", 20);
+        settings.world_flags.mm_enabled = false;
+
+        // Serialize and deserialize via YAML
+        let yaml = serde_yaml::to_string(&settings).unwrap();
+        let parsed: RandomizerSettings = serde_yaml::from_str(&yaml).unwrap();
+
+        // Verify fields
+        assert!(parsed.er_moon);
+        assert!(parsed.open_mask_shop);
+        assert_eq!(parsed.deku_tree, DekuTreeState::Open);
+        assert_eq!(parsed.door_of_time, DoorOfTimeState::Open);
+        assert_eq!(parsed.kakariko_gate, KakarikoGateState::Open);
+        assert_eq!(parsed.boss_warp_pads, BossWarpPadsMode::Remains);
+        assert_eq!(parsed.csmc, CsmcMode::Always);
+        assert_eq!(parsed.item_pool, ItemPool::Scarce);
+        assert_eq!(parsed.traps_quantity, TrapsQuantity::Many);
+        assert!(parsed.open_dungeons_oot.contains(&OotDungeon::Shadow));
+        assert!(parsed.open_dungeons_oot.contains(&OotDungeon::Water));
+        assert!(parsed.jp_layouts.contains(&JpLayout::StoneTower));
+        assert_eq!(parsed.starting_item_quantity("Bow"), 1);
+        assert_eq!(parsed.starting_item_quantity("Bombs"), 20);
+        assert!(!parsed.is_mm_enabled());
+    }
+
+    // === OotDungeon additional tests ===
+
+    #[test]
+    fn test_oot_dungeon_as_str_all_variants() {
+        assert_eq!(OotDungeon::DodongosCavern.as_str(), "DC");
+        assert_eq!(OotDungeon::BottomOfTheWell.as_str(), "BotW");
+        assert_eq!(OotDungeon::JabuJabu.as_str(), "JJ");
+        assert_eq!(OotDungeon::Shadow.as_str(), "Shadow");
+        assert_eq!(OotDungeon::Water.as_str(), "Water");
+        assert_eq!(OotDungeon::FireChild.as_str(), "fireChild");
+        assert_eq!(OotDungeon::WellAdult.as_str(), "wellAdult");
+    }
+
+    #[test]
+    fn test_oot_dungeon_roundtrip_all_variants() {
+        for dungeon in [
+            OotDungeon::DodongosCavern,
+            OotDungeon::BottomOfTheWell,
+            OotDungeon::JabuJabu,
+            OotDungeon::Shadow,
+            OotDungeon::Water,
+            OotDungeon::FireChild,
+            OotDungeon::WellAdult,
+        ] {
+            let s = dungeon.as_str();
+            assert_eq!(OotDungeon::parse(s), Some(dungeon));
+        }
+    }
+
+    #[test]
+    fn test_oot_dungeon_serde_roundtrip() {
+        for dungeon in [
+            OotDungeon::DodongosCavern,
+            OotDungeon::BottomOfTheWell,
+            OotDungeon::JabuJabu,
+            OotDungeon::Shadow,
+            OotDungeon::Water,
+            OotDungeon::FireChild,
+            OotDungeon::WellAdult,
+        ] {
+            let json = serde_json::to_string(&dungeon).unwrap();
+            let parsed: OotDungeon = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, dungeon);
+        }
+    }
+
+    // === MmDungeon additional tests ===
+
+    #[test]
+    fn test_mm_dungeon_as_str_all_variants() {
+        assert_eq!(MmDungeon::StoneTower.as_str(), "ST");
+        assert_eq!(MmDungeon::Woodfall.as_str(), "WF");
+    }
+
+    #[test]
+    fn test_mm_dungeon_roundtrip_all_variants() {
+        for dungeon in [MmDungeon::StoneTower, MmDungeon::Woodfall] {
+            let s = dungeon.as_str();
+            assert_eq!(MmDungeon::parse(s), Some(dungeon));
+        }
+    }
+
+    #[test]
+    fn test_mm_dungeon_serde_roundtrip() {
+        for dungeon in [MmDungeon::StoneTower, MmDungeon::Woodfall] {
+            let json = serde_json::to_string(&dungeon).unwrap();
+            let parsed: MmDungeon = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, dungeon);
+        }
+    }
+
+    // === MqDungeon additional tests ===
+
+    #[test]
+    fn test_mq_dungeon_as_str_all_variants() {
+        assert_eq!(MqDungeon::DekuTree.as_str(), "deku_tree");
+        assert_eq!(MqDungeon::DodongosCavern.as_str(), "dodongos_cavern");
+        assert_eq!(MqDungeon::JabuJabu.as_str(), "jabu_jabu");
+        assert_eq!(MqDungeon::ForestTemple.as_str(), "forest_temple");
+        assert_eq!(MqDungeon::FireTemple.as_str(), "fire_temple");
+        assert_eq!(MqDungeon::WaterTemple.as_str(), "water_temple");
+        assert_eq!(MqDungeon::SpiritTemple.as_str(), "spirit_temple");
+        assert_eq!(MqDungeon::ShadowTemple.as_str(), "shadow_temple");
+        assert_eq!(MqDungeon::BottomOfTheWell.as_str(), "bottom_of_the_well");
+        assert_eq!(MqDungeon::IceCavern.as_str(), "ice_cavern");
+        assert_eq!(
+            MqDungeon::GerudoTrainingGround.as_str(),
+            "gerudo_training_ground"
+        );
+        assert_eq!(MqDungeon::GanonsCastle.as_str(), "ganons_castle");
+    }
+
+    #[test]
+    fn test_mq_dungeon_serde_roundtrip_all() {
+        for dungeon in MqDungeon::all() {
+            let json = serde_json::to_string(dungeon).unwrap();
+            let parsed: MqDungeon = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, *dungeon);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Add extensive test coverage for OoTMM randomizer settings:

- Unit tests for all enum types (Default, as_str, parse, serde roundtrip)
- Unit tests for SpecialCondition struct (constructors, has_requirements)
- Unit tests for WorldFlags struct (defaults, accessors, serde)
- Unit tests for StartingItems and JunkLocations collections
- Integration tests for config file parsing (valid YAML, partial configs, error cases, empty collections, invalid values)
- Round-trip serialization tests for both JSON and YAML formats
- Comprehensive end-to-end tests covering all field types

This completes Phase 6 of the OoTMM settings implementation plan.

## Test plan
- [ ] Run `cargo test -p ootmm` to verify all new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)