### PR TITLE
test: Add location enumeration parity tests for YAML locations

### DIFF
--- a/crate/ootmm/src/world_database.rs
+++ b/crate/ootmm/src/world_database.rs
@@ -672,4 +672,40 @@ regions:
         let mm_locs: Vec<_> = db.locations_for_game(Game::Mm).collect();
         assert_eq!(mm_locs.len(), 2);
     }
+
+    /// Test that WorldDatabase.locations().count() matches the raw YAML location count.
+    ///
+    /// This verifies that the parsing pipeline doesn't lose any locations.
+    /// The YAML files use `locationType:` as the marker for each location.
+    #[test]
+    fn test_yaml_location_count_matches_world_database() {
+        use crate::embedded_data;
+
+        // Count locations directly from raw YAML by counting `locationType:` markers
+        let mut yaml_location_count = 0;
+        for (_name, content) in embedded_data::world::all() {
+            yaml_location_count += content.matches("locationType:").count();
+        }
+
+        // Load all world data into WorldDatabase
+        let db = embedded_data::create_world_database()
+            .expect("Failed to create world database from embedded data");
+
+        // Compare counts
+        let db_location_count = db.locations().count();
+
+        assert_eq!(
+            yaml_location_count, db_location_count,
+            "YAML location count ({}) should match WorldDatabase.locations().count() ({})",
+            yaml_location_count, db_location_count
+        );
+
+        // Verify we have the expected total (5865 locations)
+        const EXPECTED_TOTAL_LOCATIONS: usize = 5865;
+        assert_eq!(
+            db_location_count, EXPECTED_TOTAL_LOCATIONS,
+            "Expected {} total locations, got {}",
+            EXPECTED_TOTAL_LOCATIONS, db_location_count
+        );
+    }
 }

--- a/crate/oottracker/src/flag_mapping.rs
+++ b/crate/oottracker/src/flag_mapping.rs
@@ -5151,4 +5151,54 @@ mod tests {
         // Other vanilla dungeons should still be active
         assert!(get_active_mapping("oot_forest_temple_compass", &settings).is_some());
     }
+
+    // === Location Count Parity Tests ===
+
+    /// Test that all OoT locations from WorldDatabase are enumerable in the flag mapping.
+    ///
+    /// This verifies that the flag_mapping module correctly loads all OoT locations
+    /// from the embedded world data without losing any. The flag_mapping module may
+    /// have additional hardcoded entries, but all YAML locations must be present.
+    #[test]
+    fn test_oot_location_count_matches_world_database() {
+        // Get OoT locations from WorldDatabase
+        let db = embedded_data::create_world_database()
+            .expect("Failed to create world database from embedded data");
+
+        let world_db_oot_count = db.locations_for_game(Game::Oot).count();
+
+        // Verify the WorldDatabase has the expected OoT location count from YAML
+        // OoT has: 31 (bosses) + 744 (dungeons) + 926 (dungeons_mq) + 1397 (overworld) = 3098
+        const EXPECTED_YAML_OOT_LOCATIONS: usize = 3098;
+        assert_eq!(
+            world_db_oot_count, EXPECTED_YAML_OOT_LOCATIONS,
+            "WorldDatabase should have {} OoT locations from YAML, got {}",
+            EXPECTED_YAML_OOT_LOCATIONS, world_db_oot_count
+        );
+
+        // Verify that every location from WorldDatabase exists in the flag mapping
+        // (i.e., the pipeline doesn't lose any locations)
+        let mut missing_locations = Vec::new();
+        for (location, _region_id) in db.locations_for_game(Game::Oot) {
+            if get_mapping(&location.id).is_none() {
+                missing_locations.push(location.id.clone());
+            }
+        }
+
+        assert!(
+            missing_locations.is_empty(),
+            "Flag mapping is missing {} OoT locations from WorldDatabase: {:?}",
+            missing_locations.len(),
+            missing_locations
+        );
+
+        // Verify the flag_mapping count is at least the WorldDatabase count
+        let flag_mapping_count = oot_location_count();
+        assert!(
+            flag_mapping_count >= world_db_oot_count,
+            "oot_location_count() ({}) should be >= WorldDatabase OoT locations ({})",
+            flag_mapping_count,
+            world_db_oot_count
+        );
+    }
 }

--- a/crate/oottracker/src/mm_flag_mapping.rs
+++ b/crate/oottracker/src/mm_flag_mapping.rs
@@ -3768,4 +3768,56 @@ mod tests {
             "Unimplemented global flags should return Unknown status"
         );
     }
+
+    // === Location Count Parity Tests ===
+
+    /// Test that all MM locations from WorldDatabase are enumerable in the flag mapping.
+    ///
+    /// This verifies that the mm_flag_mapping module correctly loads all MM locations
+    /// from the embedded world data without losing any. The mm_flag_mapping module may
+    /// have additional hardcoded entries, but all YAML locations must be present.
+    #[test]
+    fn test_mm_location_count_matches_world_database() {
+        use ootmm::embedded_data;
+
+        // Get MM locations from WorldDatabase
+        let db = embedded_data::create_world_database()
+            .expect("Failed to create world database from embedded data");
+
+        let world_db_mm_count = db.locations_for_game(Game::Mm).count();
+
+        // Verify the WorldDatabase has the expected MM location count from YAML
+        // MM has: 46 (bosses) + 934 (dungeons) + 1785 (overworld) + 2 (us_variant) = 2767
+        const EXPECTED_YAML_MM_LOCATIONS: usize = 2767;
+        assert_eq!(
+            world_db_mm_count, EXPECTED_YAML_MM_LOCATIONS,
+            "WorldDatabase should have {} MM locations from YAML, got {}",
+            EXPECTED_YAML_MM_LOCATIONS, world_db_mm_count
+        );
+
+        // Verify that every location from WorldDatabase exists in the flag mapping
+        // (i.e., the pipeline doesn't lose any locations)
+        let mut missing_locations = Vec::new();
+        for (location, _region_id) in db.locations_for_game(Game::Mm) {
+            if get_mm_mapping(&location.id).is_none() {
+                missing_locations.push(location.id.clone());
+            }
+        }
+
+        assert!(
+            missing_locations.is_empty(),
+            "MM flag mapping is missing {} locations from WorldDatabase: {:?}",
+            missing_locations.len(),
+            missing_locations
+        );
+
+        // Verify the mm_flag_mapping count is at least the WorldDatabase count
+        let flag_mapping_count = mm_location_count();
+        assert!(
+            flag_mapping_count >= world_db_mm_count,
+            "mm_location_count() ({}) should be >= WorldDatabase MM locations ({})",
+            flag_mapping_count,
+            world_db_mm_count
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Add tests to verify that all YAML locations are enumerable in the check tracker pipeline:

- **world_database.rs**: Test that `WorldDatabase.locations().count()` matches the raw YAML location count (5865 total locations)
- **flag_mapping.rs**: Test that all OoT locations from WorldDatabase are present in the flag mapping (3098 OoT locations)
- **mm_flag_mapping.rs**: Test that all MM locations from WorldDatabase are present in the flag mapping (2767 MM locations)

These tests verify the pipeline doesn't lose any locations during parsing and loading.

Closes #612

## Test plan
- [ ] Run `cargo test` to verify all new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)