### PR TITLE
feat: Add option to hide MQ dungeon checks in web tracker

### DIFF
--- a/assets/web/static/checked-locations.css
+++ b/assets/web/static/checked-locations.css
@@ -91,6 +91,9 @@
     background: rgba(0, 0, 0, 0.5);
     padding: 8px 12px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .checked-locations-panel .filter-checkbox-label {

--- a/assets/web/static/checked-locations.js
+++ b/assets/web/static/checked-locations.js
@@ -19,6 +19,7 @@ let checkedLocationsState = {
     collapsedRegions: new Set(), // Track which regions are collapsed
     pendingSkipToggles: new Set(), // Track locations with pending skip toggle requests
     hideUnavailable: false, // Filter to hide inaccessible locations
+    hideMqLocations: false, // Filter to hide Master Quest dungeon checks
     // Auto-scroll state
     lastSceneId: null,           // Track last seen scene ID for detecting changes
     lastGame: null,              // Track which game was active ('oot' or 'mm')
@@ -568,9 +569,45 @@ function toggleHideUnavailable() {
 }
 
 /**
+ * Toggle the hide MQ locations filter
+ */
+function toggleHideMqLocations() {
+    checkedLocationsState.hideMqLocations = !checkedLocationsState.hideMqLocations;
+    // Save preference to localStorage
+    localStorage.setItem('oottracker_hide_mq_locations', checkedLocationsState.hideMqLocations);
+    // Re-render the list
+    const data = {
+        locations: Object.entries(checkedLocationsState.locations).map(([id, locData]) => ({
+            location_id: id,
+            status: locData.status,
+            accessibility: locData.accessibility
+        }))
+    };
+    updateLocationsList(data);
+    // Update checkbox state
+    const checkbox = document.getElementById('hide-mq-checkbox');
+    if (checkbox) {
+        checkbox.checked = checkedLocationsState.hideMqLocations;
+    }
+}
+
+/**
+ * Check if a location ID represents a Master Quest dungeon check.
+ * MQ locations use the "mq_oot_mq_" prefix to distinguish from vanilla.
+ */
+function isMqLocation(locationId) {
+    return locationId.startsWith('mq_oot_mq_');
+}
+
+/**
  * Check if a location should be hidden based on current filter settings
  */
 function shouldHideLocation(locationId, status) {
+    // Check MQ filter first (applies regardless of check status)
+    if (checkedLocationsState.hideMqLocations && isMqLocation(locationId)) {
+        return true;
+    }
+
     if (!checkedLocationsState.hideUnavailable) {
         return false;
     }
@@ -649,6 +686,24 @@ function createCheckedLocationsPanel() {
     filterLabel.appendChild(filterCheckbox);
     filterLabel.appendChild(filterText);
     filterControls.appendChild(filterLabel);
+
+    // Hide MQ locations checkbox
+    const mqLabel = document.createElement('label');
+    mqLabel.className = 'filter-checkbox-label';
+
+    const mqCheckbox = document.createElement('input');
+    mqCheckbox.type = 'checkbox';
+    mqCheckbox.id = 'hide-mq-checkbox';
+    mqCheckbox.checked = checkedLocationsState.hideMqLocations;
+    mqCheckbox.addEventListener('change', toggleHideMqLocations);
+
+    const mqText = document.createElement('span');
+    mqText.textContent = 'Hide MQ checks';
+    mqText.title = 'Hide Master Quest dungeon checks (for vanilla dungeon playthroughs)';
+
+    mqLabel.appendChild(mqCheckbox);
+    mqLabel.appendChild(mqText);
+    filterControls.appendChild(mqLabel);
 
     const list = document.createElement('div');
     list.className = 'locations-list';
@@ -1142,10 +1197,15 @@ function initCheckedLocations() {
         return;
     }
 
-    // Load saved filter preference from localStorage
+    // Load saved filter preferences from localStorage
     const savedHideUnavailable = localStorage.getItem('oottracker_hide_unavailable');
     if (savedHideUnavailable !== null) {
         checkedLocationsState.hideUnavailable = savedHideUnavailable === 'true';
+    }
+
+    const savedHideMq = localStorage.getItem('oottracker_hide_mq_locations');
+    if (savedHideMq !== null) {
+        checkedLocationsState.hideMqLocations = savedHideMq === 'true';
     }
 
     // Create UI elements


### PR DESCRIPTION
## Summary
Add a checkbox filter to hide Master Quest dungeon checks from the checked locations panel. This allows users playing vanilla dungeons to hide MQ-specific checks that don't apply to their playthrough.

- Adds checkbox to toggle MQ location visibility
- Setting persists in localStorage as `oottracker_hide_mq_locations`
- MQ locations identified by `mq_oot_mq_` prefix in their IDs

Closes #618

## Test plan
- [ ] Verify checkbox appears in checked locations panel
- [ ] Verify checking the box hides MQ locations
- [ ] Verify setting persists after page reload
- [ ] Verify vanilla locations still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)