### PR TITLE
fix(mm): Correct MmDungeonItems bitfield for N64 big-endian

### DIFF
--- a/crate/oottracker/src/mm_save/dungeon_progress.rs
+++ b/crate/oottracker/src/mm_save/dungeon_progress.rs
@@ -8,12 +8,17 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Dungeon items for a single dungeon
+    ///
+    /// N64 big-endian bitfield layout (from OoTMM MmDungeonItems):
+    /// - bits 4-0: maxKeys (5 bits, handled separately)
+    /// - bit 5: map
+    /// - bit 6: compass
+    /// - bit 7: bossKey (MSB)
     #[derive(Default)]
     pub struct MmDungeonItems: u8 {
-        const BOSS_KEY = 0x01;
-        const COMPASS = 0x02;
-        const MAP = 0x04;
-        // Note: maxKeys is stored in bits 3-7 but we handle that separately
+        const BOSS_KEY = 0x80;  // bit 7 (MSB)
+        const COMPASS = 0x40;   // bit 6
+        const MAP = 0x20;       // bit 5
     }
 }
 

--- a/crate/oottracker/src/mm_save/tests.rs
+++ b/crate/oottracker/src/mm_save/tests.rs
@@ -304,14 +304,16 @@ mod tests {
 
         let mut data = vec![0u8; MM_SIZE];
 
-        // Woodfall: Map + Compass + Boss Key (0x07)
-        data[DUNGEON_ITEMS] = 0x07;
-        // Snowhead: Map only (0x04)
-        data[DUNGEON_ITEMS + 1] = 0x04;
-        // Great Bay: Compass only (0x02)
-        data[DUNGEON_ITEMS + 2] = 0x02;
-        // Stone Tower: Boss Key only (0x01)
-        data[DUNGEON_ITEMS + 3] = 0x01;
+        // N64 big-endian bitfield layout:
+        // bit 7: bossKey (0x80), bit 6: compass (0x40), bit 5: map (0x20)
+        // Woodfall: Map + Compass + Boss Key (0xE0)
+        data[DUNGEON_ITEMS] = 0xE0;
+        // Snowhead: Map only (0x20)
+        data[DUNGEON_ITEMS + 1] = 0x20;
+        // Great Bay: Compass only (0x40)
+        data[DUNGEON_ITEMS + 2] = 0x40;
+        // Stone Tower: Boss Key only (0x80)
+        data[DUNGEON_ITEMS + 3] = 0x80;
 
         let save = MmSave::from_save_data(&data).unwrap();
         assert!(save.dungeon_items.woodfall.contains(MmDungeonItems::MAP));


### PR DESCRIPTION
## Summary
- N64 is big-endian, bitfields pack from MSB to LSB
- Changed BOSS_KEY from 0x01 to 0x80 (bit 7)
- Changed COMPASS from 0x02 to 0x40 (bit 6)
- Changed MAP from 0x04 to 0x20 (bit 5)

## Reference
OoTMM MmDungeonItems structure: `bossKey:1` at bit 7 (MSB)

Fixes #654

🤖 Generated with [Claude Code](https://claude.ai/code)