### PR TITLE
fix(combo): Remove incorrect COMBO_MM_RAM_RANGES

### DIFF
--- a/assets/oottracker-pj64em.lua
+++ b/assets/oottracker-pj64em.lua
@@ -24,14 +24,10 @@ MM_RAM_RANGES = {
     0x1ef670, 0x48d0   -- MM save context
 }
 
--- COMBO_MM_RAM_RANGES: {addr1, len1}
--- OoTMM combo uses a different address for MM save context
-COMBO_MM_RAM_RANGES = {
-    0x98280, 0x48d0    -- MM save context in OoTMM combo
-}
-
 -- The constants above are generated from Rust code in crate/oottracker-utils/src/release.rs. If they're missing, you have the wrong file.
 -- Generated constants include: TCP_PORT, SAVE_ADDR, SAVE_SIZE, RAM_RANGES, MM_SAVE_ADDR, MM_SAVE_SIZE, MM_RAM_RANGES, OOT_COMBO_CONTEXT_ADDR, MM_COMBO_CONTEXT_ADDR
+-- Note: In combo mode, MM save data is only accessible when the MM engine is running (i.e., when in MM world).
+-- The MM_COMBO_CONTEXT_ADDR is only used for detecting combo mode, NOT for reading MM save data.
 
 local VERSION = 6 -- do not rename this variable, the build script checks against it
 
@@ -495,9 +491,9 @@ local function main()
         if detectedGame == GAME_TYPE_OOT or detectedGame == GAME_TYPE_COMBO then
             -- For combo mode, check if we're in MM world
             if detectedGame == GAME_TYPE_COMBO and comboActiveWorld == COMBO_WORLD_MM then
-                -- In MM world of combo - handle MM data from COMBO_MM_RAM_RANGES
-                -- (OoTMM uses a different memory address than vanilla MM)
-                local mmRanges = COMBO_MM_RAM_RANGES or MM_RAM_RANGES
+                -- In MM world of combo - read MM data from standard MM save address
+                -- (MM save data at 0x1ef670 is only valid when MM engine runs)
+                local mmRanges = MM_RAM_RANGES
                 if mmRanges ~= nil then
                     local mmChanged = true
                     if rawMmRam == nil then
@@ -539,33 +535,10 @@ local function main()
             -- Send OoT RAM data
             sendOotRamData(sock, rawRam)
 
-            -- For combo mode, also read and send MM data from combo address
-            if detectedGame == GAME_TYPE_COMBO then
-                -- OoTMM uses a different memory address for MM save context
-                local mmRanges = COMBO_MM_RAM_RANGES or MM_RAM_RANGES
-                if mmRanges ~= nil then
-                    local mmChanged = rawMmRam == nil
-                    if rawMmRam == nil then
-                        rawMmRam = {}
-                    end
-                    local rangeIdx = 1
-                    for i = 1, #mmRanges, 2 do
-                        local addr = mmRanges[i]
-                        local size = mmRanges[i + 1]
-                        local newRange = readMemoryBlock(RDRAM_BASE + addr, size)
-                        if rawMmRam[rangeIdx] == nil or not arraysEqual(newRange, rawMmRam[rangeIdx]) then
-                            rawMmRam[rangeIdx] = newRange
-                            mmChanged = true
-                        end
-                        rangeIdx = rangeIdx + 1
-                    end
-                    -- In combo mode, always send MM data when OoT data is sent
-                    -- (since they share the same save file)
-                    if mmChanged and rawMmRam ~= nil then
-                        sendMmRamData(sock, rawMmRam)
-                    end
-                end
-            end
+            -- Note: In combo mode, MM save data is only accessible when in MM world
+            -- (handled above in the comboActiveWorld == COMBO_WORLD_MM block).
+            -- When in OoT world, the MM save is stored in gMmSave at a dynamic address
+            -- that isn't accessible from the emulator, so we don't try to read it here.
         end
     end
 

--- a/crate/oottracker/src/ram.rs
+++ b/crate/oottracker/src/ram.rs
@@ -67,10 +67,21 @@ pub static MM_RANGES: [u32; MM_NUM_RANGES * 2] = [
 // ============================================================================
 // Combo Context Addresses (for OoTMM game detection)
 // ============================================================================
+//
+// IMPORTANT: These addresses are for the ComboContext struct (24 bytes) used
+// for world-switch coordination and combo mode detection ONLY.
+// They should NOT be used for reading MM save data.
+//
+// In OoTMM combo mode:
+// - MM save data at MM_SAVE_ADDR (0x1ef670) is only valid when MM engine runs
+// - When OoT engine runs, MM save is in gMmSave (dynamic address, not accessible)
 
 /// OoT combo context address offset (0x80006584 - 0x80000000)
+/// Used for detecting if OoTMM combo mode is active (non-zero = combo detected)
 pub const OOT_COMBO_CONTEXT_ADDR: u32 = 0x6584;
 /// MM combo context address offset (0x80098280 - 0x80000000)
+/// Used for detecting if OoTMM combo mode is active (non-zero = combo detected)
+/// NOTE: This is NOT the MM save context address - do not use for reading MM save data.
 pub const MM_COMBO_CONTEXT_ADDR: u32 = 0x98280;
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- COMBO_MM_RAM_RANGES read 0x48d0 bytes from ComboContext (only 24 bytes)
- This caused ALL MM data to be garbage in combo mode
- Removed the incorrect constant entirely
- MM data now only read when MM engine is active

## Root Cause
- 0x98280 is ComboContext (24 bytes), not MmSaveContext
- When in OoT world, MM save is in dynamic gMmSave (not accessible)

Fixes #649

🤖 Generated with [Claude Code](https://claude.ai/code)